### PR TITLE
[FEAT] FCM 기반 알림 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### firebase ###
+/src/main/resources/firebase/dorumdorum-9ce75-firebase-adminsdk-fbsvc-8d66c0dccb.json

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     // SMTP
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // Firebase
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'

--- a/src/main/java/com/project/dorumdorum/domain/notification/application/dto/request/SendFirebaseTokenRequest.java
+++ b/src/main/java/com/project/dorumdorum/domain/notification/application/dto/request/SendFirebaseTokenRequest.java
@@ -1,0 +1,9 @@
+package com.project.dorumdorum.domain.notification.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SendFirebaseTokenRequest(
+        @NotBlank String firebaseToken
+) {
+}
+

--- a/src/main/java/com/project/dorumdorum/domain/notification/application/usecase/SendFirebaseTokenUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/notification/application/usecase/SendFirebaseTokenUseCase.java
@@ -1,0 +1,20 @@
+package com.project.dorumdorum.domain.notification.application.usecase;
+
+import com.project.dorumdorum.domain.notification.application.dto.request.SendFirebaseTokenRequest;
+import com.project.dorumdorum.domain.notification.domain.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendFirebaseTokenUseCase {
+
+    private final NotificationService notificationService;
+
+    public void execute(Long userNo, SendFirebaseTokenRequest request) {
+        notificationService.saveToken(userNo, request.firebaseToken());
+    }
+}
+

--- a/src/main/java/com/project/dorumdorum/domain/notification/domain/service/NotificationService.java
+++ b/src/main/java/com/project/dorumdorum/domain/notification/domain/service/NotificationService.java
@@ -1,24 +1,85 @@
 package com.project.dorumdorum.domain.notification.domain.service;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
 import com.project.dorumdorum.domain.user.domain.entity.User;
 import com.project.dorumdorum.domain.user.domain.repository.UserRepository;
 import com.project.dorumdorum.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
+import java.util.Map;
+
+import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.FIREBASE_TOKEN_NOT_FOUND;
+import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.NOTIFICATION_FAILED;
 import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationService {
 
     private final UserRepository userRepository;
+    private final FirebaseMessaging firebaseMessaging;
 
+    @Transactional
     public void saveToken(Long userNo, String firebaseToken) {
         User user = userRepository.findById(userNo)
                 .orElseThrow(() -> new RestApiException(_NOT_FOUND));
 
         user.updateFirebaseToken(firebaseToken);
+    }
+
+    @Transactional
+    public String sendNotification(Long receiverUserNo, String title, String body, Map<String, String> data, String imageUrl) {
+        User receiver = userRepository.findById(receiverUserNo)
+                .orElseThrow(() -> new RestApiException(_NOT_FOUND));
+
+        if (!StringUtils.hasText(receiver.getFirebaseToken())) {
+            throw new RestApiException(FIREBASE_TOKEN_NOT_FOUND);
+        }
+
+        Message.Builder messageBuilder = Message.builder()
+                .setToken(receiver.getFirebaseToken())
+                .setNotification(
+                        Notification.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .setImage(imageUrl)
+                                .build()
+                );
+
+        if (!CollectionUtils.isEmpty(data)) {
+            messageBuilder.putAllData(data);
+        }
+
+        try {
+            // 알림 보내기
+            String messageId = firebaseMessaging.send(messageBuilder.build());
+            log.info("[FCM] sent messageId={} to userNo={} tokenExists={}", messageId, receiverUserNo, true);
+            return messageId;
+        } catch (FirebaseMessagingException e) {
+            MessagingErrorCode errorCode = e.getMessagingErrorCode();
+
+            // 만료/등록 해제된 토큰이면 토큰을 비우고 클라이언트가 재등록하도록 유도
+            if (errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
+                log.warn("[FCM] invalid/expired token. userNo={} token={} errorCode={} message={}",
+                        receiverUserNo, receiver.getFirebaseToken(), errorCode, e.getMessage());
+                receiver.updateFirebaseToken(null);
+                throw new RestApiException(FIREBASE_TOKEN_NOT_FOUND);
+            }
+
+            log.error("[FCM] send failed. userNo={} token={} errorCode={} message={}",
+                    receiverUserNo, receiver.getFirebaseToken(), errorCode, e.getMessage(), e);
+            throw new RestApiException(NOTIFICATION_FAILED);
+        }
     }
 }
 

--- a/src/main/java/com/project/dorumdorum/domain/notification/domain/service/NotificationService.java
+++ b/src/main/java/com/project/dorumdorum/domain/notification/domain/service/NotificationService.java
@@ -1,0 +1,24 @@
+package com.project.dorumdorum.domain.notification.domain.service;
+
+import com.project.dorumdorum.domain.user.domain.entity.User;
+import com.project.dorumdorum.domain.user.domain.repository.UserRepository;
+import com.project.dorumdorum.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final UserRepository userRepository;
+
+    public void saveToken(Long userNo, String firebaseToken) {
+        User user = userRepository.findById(userNo)
+                .orElseThrow(() -> new RestApiException(_NOT_FOUND));
+
+        user.updateFirebaseToken(firebaseToken);
+    }
+}
+

--- a/src/main/java/com/project/dorumdorum/domain/notification/ui/SendFirebaseTokenController.java
+++ b/src/main/java/com/project/dorumdorum/domain/notification/ui/SendFirebaseTokenController.java
@@ -1,0 +1,27 @@
+package com.project.dorumdorum.domain.notification.ui;
+
+import com.project.dorumdorum.domain.notification.application.dto.request.SendFirebaseTokenRequest;
+import com.project.dorumdorum.domain.notification.application.usecase.SendFirebaseTokenUseCase;
+import com.project.dorumdorum.domain.notification.ui.spec.SendFirebaseTokenApiSpec;
+import com.project.dorumdorum.global.annotation.CurrentUser;
+import com.project.dorumdorum.global.common.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SendFirebaseTokenController implements SendFirebaseTokenApiSpec {
+
+    private final SendFirebaseTokenUseCase sendFirebaseTokenUseCase;
+
+    @Override
+    public BaseResponse<Void> sendFirebaseToken(
+            @CurrentUser Long userNo,
+            @RequestBody @Valid SendFirebaseTokenRequest request
+    ) {
+        sendFirebaseTokenUseCase.execute(userNo, request);
+        return BaseResponse.onSuccess();
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/notification/ui/spec/SendFirebaseTokenApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/notification/ui/spec/SendFirebaseTokenApiSpec.java
@@ -1,0 +1,28 @@
+package com.project.dorumdorum.domain.notification.ui.spec;
+
+import com.project.dorumdorum.domain.notification.application.dto.request.SendFirebaseTokenRequest;
+import com.project.dorumdorum.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "Notification")
+public interface SendFirebaseTokenApiSpec {
+
+    @Operation(
+            summary = "FCM 토큰 등록 API",
+            description = "로그인한 사용자가 자신의 FCM 디바이스 토큰을 서버에 등록합니다."
+    )
+    @PostMapping("/api/notification")
+    BaseResponse<Void> sendFirebaseToken(
+            @Parameter(hidden = true) Long userNo,
+            @RequestBody(
+                    description = "FCM 디바이스 토큰",
+                    required = true
+            )
+            SendFirebaseTokenRequest request
+    );
+}
+

--- a/src/main/java/com/project/dorumdorum/domain/user/domain/entity/User.java
+++ b/src/main/java/com/project/dorumdorum/domain/user/domain/entity/User.java
@@ -37,10 +37,16 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    private String firebaseToken;
+
     public void updateProfile(UpdateProfileRequest updateProfileRequest) {
         this.name = updateProfileRequest.name();
         this.nickname = updateProfileRequest.nickname();
         this.email = updateProfileRequest.email();
+    }
+
+    public void updateFirebaseToken(String firebaseToken) {
+        this.firebaseToken = firebaseToken;
     }
 
 }

--- a/src/main/java/com/project/dorumdorum/global/config/FirebaseConfig.java
+++ b/src/main/java/com/project/dorumdorum/global/config/FirebaseConfig.java
@@ -1,0 +1,44 @@
+package com.project.dorumdorum.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.project.dorumdorum.global.properties.FirebaseProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+@RequiredArgsConstructor
+public class FirebaseConfig {
+
+    private final FirebaseProperties firebaseProperties;
+
+    // firebase app 초기화
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.getInstance();
+        }
+
+        Resource resource = new ClassPathResource(firebaseProperties.getServiceAccount().getPath());
+        try (InputStream inputStream = resource.getInputStream()) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(inputStream))
+                    .build();
+            return FirebaseApp.initializeApp(options);
+        }
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}
+

--- a/src/main/java/com/project/dorumdorum/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/dorumdorum/global/config/SecurityConfig.java
@@ -83,7 +83,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of(
+            "http://localhost:3000",
+            "http://localhost:5173"
+        ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("Authorization"));

--- a/src/main/java/com/project/dorumdorum/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/dorumdorum/global/config/SecurityConfig.java
@@ -17,6 +17,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Slf4j
 @Configuration
@@ -33,6 +38,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http.csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable);
@@ -42,6 +48,7 @@ public class SecurityConfig {
                     .forEachRemaining(authPath ->
                             request.requestMatchers(HttpMethod.valueOf(authPath.getMethod()), authPath.getPathPattern()).permitAll()
                     );
+            request.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
         });
 
         http.authorizeHttpRequests(request -> request
@@ -71,5 +78,19 @@ public class SecurityConfig {
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/project/dorumdorum/global/exception/code/status/GlobalErrorStatus.java
+++ b/src/main/java/com/project/dorumdorum/global/exception/code/status/GlobalErrorStatus.java
@@ -52,7 +52,11 @@ public enum GlobalErrorStatus implements BaseCodeInterface {
     FRIENDSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND005", "친구가 아닙니다."),
     REQUEST_NOT_RECEIVER(HttpStatus.FORBIDDEN, "FRIEND006", "해당 친구추가 요청의 수신자가 아닙니다."),
     REQUEST_NOT_SENDER(HttpStatus.FORBIDDEN, "FRIEND007", "해당 친구추가 요청의 발신자가 아닙니다."),
-    REQUEST_NOT_PENDING(HttpStatus.BAD_REQUEST, "FRIEND008", "해당 친구추가 요청이 대기 상태가 아닙니다.")
+    REQUEST_NOT_PENDING(HttpStatus.BAD_REQUEST, "FRIEND008", "해당 친구추가 요청이 대기 상태가 아닙니다."),
+
+    // Notification
+    FIREBASE_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTIFICATION001", "수신자의 FCM 토큰이 등록되어 있지 않습니다."),
+    NOTIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION002", "알림 전송 중 서버 에러")
 
     ;
 

--- a/src/main/java/com/project/dorumdorum/global/properties/FirebaseProperties.java
+++ b/src/main/java/com/project/dorumdorum/global/properties/FirebaseProperties.java
@@ -1,0 +1,20 @@
+package com.project.dorumdorum.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "firebase")
+public class FirebaseProperties {
+
+    private final ServiceAccount serviceAccount = new ServiceAccount();
+
+    @Getter
+    @Setter
+    public static class ServiceAccount {
+        private String path;
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     username: ${RDB_USERNAME}
     url: ${RDB_URL}
-    password: ${RDB_password}
+    password: ${RDB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   data:
     redis:
@@ -120,3 +120,7 @@ springdoc:
 include-email-domains:
   domains:
     - gachon.ac.kr
+
+firebase:
+  service-account:
+    path: "/firebase/dorumdorum-9ce75-firebase-adminsdk-fbsvc-8d66c0dccb.json"


### PR DESCRIPTION
# 📝 Pull Request Template

## 📌 제목
fcm 기반 알림 기능 구현

---

## 📢 요약
fcm 토큰을 클라이언트가 알림 권한 허용 시 받게 하고, 
해당 토큰을 서버로 보내어 User 엔터티에 저장,
토큰이 있는 user에 대해 Id를 기준으로 푸쉬 알림 보냄

🔗 **연관 이슈**: Resolves #이슈번호

---

## 🚀 PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [ ] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## ✅ PR 체크리스트

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 기타
알림 기록을 저장하기 위해 알림 테이블을 하나 만드는 게 어떨까요?
pk, userId(fk), title, body, data, type, (base entity) 등