### PR TITLE
[FEAT] 회원가입·로그인 API 연동 및 내 방 조회 기능 구현

### DIFF
--- a/src/main/java/com/project/dorumdorum/DorumdorumApplication.java
+++ b/src/main/java/com/project/dorumdorum/DorumdorumApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
+@EnableJpaAuditing
 @SpringBootApplication
 @ConfigurationPropertiesScan
-@EnableJpaAuditing
 public class DorumdorumApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/project/dorumdorum/domain/room/application/dto/response/FindRoomsResponse.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/dto/response/FindRoomsResponse.java
@@ -1,5 +1,6 @@
 package com.project.dorumdorum.domain.room.application.dto.response;
 
+import com.project.dorumdorum.domain.room.domain.entity.RoomStatus;
 import com.project.dorumdorum.domain.room.domain.entity.RoomType;
 import com.project.dorumdorum.domain.room.domain.entity.Tag;
 import lombok.Builder;
@@ -16,5 +17,6 @@ public record FindRoomsResponse(
         LocalDateTime createdAt,
         String title,
         String hostNickname,
-        List<Tag> additionalTag
+        List<Tag> additionalTag,
+        RoomStatus roomStatus
 ) {}

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/ApplyRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/ApplyRoomUseCase.java
@@ -30,12 +30,9 @@ public class ApplyRoomUseCase {
 
         Room room = roomService.findById(roomNo);
 
-        // 확정된 방이 있는 유저인가 검증
-        if(roommateService.isCompletedRoomExists(userNo))
-            throw new RestApiException(COMPLETED_ROOM_EXISTS);
-        // 이미 속한 방인지 검증
-        if (roommateService.isUserInRoom(userNo, room))
-            throw new RestApiException(USER_IN_ROOM);
+        // 속한 방이 있는 유저인가 검증
+        if(roommateService.existsByUserNo(userNo))
+            throw new RestApiException(ALREADY_JOINED_USER);
         // 이미 보낸 요청인지 검증
         if (roomRequestService.isDuplicateJoinRequest(userNo, room))
             throw new RestApiException(DUPLICATE_JOIN_REQUEST);

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DecideApplicationRequestUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DecideApplicationRequestUseCase.java
@@ -12,8 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.COMPLETED_ROOM_EXISTS;
-import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.NO_PERMISSION_ON_ROOM;
+import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.*;
 
 @Service
 @Transactional
@@ -29,10 +28,10 @@ public class DecideApplicationRequestUseCase {
         // 유저 존재 유무 검증
         userService.validateExistsById(userNo);
 
-        // 지원자에게 확정된 방이 존재하는지 검증
+        // 지원자가 이미 속한 방이 있는지 검증
         RoomRequest roomRequest = roomRequestService.findById(roomRequestNo);
-        if(roommateService.isCompletedRoomExists(userNo))
-            throw new RestApiException(COMPLETED_ROOM_EXISTS);
+        if(roommateService.existsByUserNo(userNo))
+            throw new RestApiException(ALREADY_JOINED_USER);
 
         // 방장인지 확인
         Room room = roomService.findById(roomNo);

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DecideRoomConfirmationUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DecideRoomConfirmationUseCase.java
@@ -33,7 +33,7 @@ public class DecideRoomConfirmationUseCase {
     public void reject(Long userNo, Long roomNo) {
         Room room = roomService.findById(roomNo);
 
-        if(roommateService.isUserInRoom(userNo, room))
+        if(!roommateService.isUserInRoom(userNo, room))
             throw new RestApiException(NO_PERMISSION_ON_ROOM);
 
         room.updateStatus(RoomStatus.CONFIRM_PENDING);

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/FindRoomsUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/FindRoomsUseCase.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.ALREADY_JOINED_USER;
 import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.COMPLETED_ROOM_EXISTS;
 
 @Service
@@ -36,9 +37,9 @@ public class FindRoomsUseCase {
             RoomSort sort,
             String cursor
     ) {
-        // 내가 이미 확정된 방이 있는지
-        if(roommateService.isCompletedRoomExists(userNo))
-            throw new RestApiException(COMPLETED_ROOM_EXISTS);
+        // 내가 이미 속한 방이 있는지
+        if(roommateService.existsByUserNo(userNo))
+            throw new RestApiException(ALREADY_JOINED_USER);
 
         int limitPlusOne = PaginationHelper.limitPlusOne(limit);
         DecodedCursor decodedCursor = cursor == null

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/InviteRoomRequestUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/InviteRoomRequestUseCase.java
@@ -32,12 +32,9 @@ public class InviteRoomRequestUseCase {
         // 방장인지 확인
         if(!roommateService.isHost(userNo, room))
             throw new RestApiException(NO_PERMISSION_ON_ROOM);
-        // 확정된 방이 있는 유저인가 검증
-        if(roommateService.isCompletedRoomExists(toUser))
-            throw new RestApiException(COMPLETED_ROOM_EXISTS);
-        // 이미 속한 방인지 검증
-        if (roommateService.isUserInRoom(toUser, room))
-            throw new RestApiException(USER_IN_ROOM);
+        // 이미 속한 방이 있는 유저인가 검증
+        if(roommateService.existsByUserNo(toUser))
+            throw new RestApiException(ALREADY_JOINED_USER);
         // 이미 보낸 요청인지 검증
         if (roomRequestService.isDuplicateJoinRequest(toUser, room))
             throw new RestApiException(DUPLICATE_JOIN_REQUEST);

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/LoadMyAppliedRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/LoadMyAppliedRoomUseCase.java
@@ -1,0 +1,16 @@
+package com.project.dorumdorum.domain.room.application.usecase;
+
+import com.project.dorumdorum.domain.room.domain.service.RoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LoadMyAppliedRoomUseCase {
+
+    private final RoomService roomService;
+
+
+}

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/LoadMyRoomsUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/LoadMyRoomsUseCase.java
@@ -1,6 +1,9 @@
 package com.project.dorumdorum.domain.room.application.usecase;
 
+import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
+import com.project.dorumdorum.domain.room.domain.entity.Roommate;
 import com.project.dorumdorum.domain.room.domain.service.RoomService;
+import com.project.dorumdorum.domain.room.domain.service.RoommateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,5 +13,7 @@ public class LoadMyRoomsUseCase {
 
     private final RoomService roomService;
 
-
+    public FindRoomsResponse execute(Long userNo) {
+        return roomService.findMyRoom(userNo);
+    }
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomRepositoryCustom.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomRepositoryCustom.java
@@ -8,9 +8,11 @@ import com.project.dorumdorum.domain.room.domain.entity.Tag;
 import com.project.dorumdorum.global.pagination.DecodedCursor;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RoomRepositoryCustom {
 
     List<FindRoomsResponse> findByCursor(Long userNo, RoomRelation relation, List<Tag> tags, RoomType type, Integer capacity, RoomSort sort, DecodedCursor decodedCursor, int limitPlusOne);
 
+    Optional<FindRoomsResponse> findMyRoom(Long userNo);
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoommateRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoommateRepository.java
@@ -10,8 +10,10 @@ import java.util.Optional;
 public interface RoommateRepository extends JpaRepository<Roommate, Long> {
 
     Boolean existsByUserNoAndRoom(Long userNo, Room room);
-    List<Roommate> findByUserNo(Long userNo);
+    List<Roommate> findAllByUserNo(Long userNo);
     Optional<Roommate> findByUserNoAndRoom(Long userNo, Room room);
     List<Roommate> findByRoom(Room room);
+    Optional<Roommate> findByUserNo(Long userNo);
+    boolean existsByUserNo(Long userNo);
 
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.ROOM_NOT_FOUND;
 import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
 
 @Service
@@ -41,5 +42,10 @@ public class RoomService {
 
     public List<FindRoomsResponse> findByCursor(Long userNo, RoomRelation relation, List<Tag> tags, RoomType type, Integer capacity, RoomSort sort, DecodedCursor decodedCursor, int limitPlusOne) {
         return roomRepository.findByCursor(userNo, relation, tags, type, capacity, sort, decodedCursor, limitPlusOne);
+    }
+
+    public FindRoomsResponse findMyRoom(Long userNo) {
+        return roomRepository.findMyRoom(userNo)
+                .orElseThrow(() -> new RestApiException(ROOM_NOT_FOUND));
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoommateService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoommateService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus.ROOMMATE_NOT_FOUND;
 import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
 
 @Service
@@ -34,13 +35,8 @@ public class RoommateService {
         return roommateRepository.existsByUserNoAndRoom(userNo, room);
     }
 
-    public Boolean isCompletedRoomExists(Long userNo) {
-        for (Roommate roommate : roommateRepository.findByUserNo(userNo)) {
-            if (roommate.isCompleted())
-                return true;
-        }
-
-        return false;
+    public Boolean existsByUserNo(Long userNo) {
+        return roommateRepository.existsByUserNo(userNo);
     }
 
     public Boolean isHost(Long userNo, Room room) {
@@ -55,5 +51,10 @@ public class RoommateService {
 
     public List<Roommate> findByRoom(Room room) {
         return roommateRepository.findByRoom(room);
+    }
+
+    public Roommate findByUserNo(Long userNo) {
+        return roommateRepository.findByUserNo(userNo)
+                .orElseThrow(() -> new RestApiException(ROOMMATE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.project.dorumdorum.domain.room.domain.entity.QRoom.room;
 import static com.project.dorumdorum.domain.room.domain.entity.QRoomRequest.roomRequest;
@@ -49,7 +50,8 @@ public class RoomRepositoryImpl implements RoomRepositoryCustom {
                                 room.createdAt,
                                 room.title,
                                 user.nickname,
-                                room.tags
+                                room.tags,
+                                room.roomStatus
                         )
                 )
                 .from(room)
@@ -69,6 +71,36 @@ public class RoomRepositoryImpl implements RoomRepositoryCustom {
         }
 
         return q.limit(limitPlusOne).fetch();
+    }
+
+    @Override
+    public Optional<FindRoomsResponse> findMyRoom(Long userNo) {
+        FindRoomsResponse result = query
+                .select(
+                        constructor(FindRoomsResponse.class,
+                                room.roomNo,
+                                room.roomType,
+                                room.capacity,
+                                room.currentMateCount,
+                                room.createdAt,
+                                room.title,
+                                user.nickname,
+                                room.tags,
+                                room.roomStatus
+                        )
+                )
+                .from(room)
+                .leftJoin(user).on(user.userNo.eq(room.hostUserNo))
+                .where(
+                        JPAExpressions
+                                .selectOne()
+                                .from(roommate)
+                                .where(roommate.room.eq(room), roommate.userNo.eq(userNo))
+                                .exists()
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 
     private BooleanExpression relationPredicate(Long userNo, RoomRelation relation) {

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/LoadMyRoomController.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/LoadMyRoomController.java
@@ -1,0 +1,24 @@
+package com.project.dorumdorum.domain.room.ui;
+
+import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
+import com.project.dorumdorum.domain.room.application.usecase.LoadMyRoomsUseCase;
+import com.project.dorumdorum.domain.room.ui.spec.LoadMyRoomsApiSpec;
+import com.project.dorumdorum.global.annotation.CurrentUser;
+import com.project.dorumdorum.global.common.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LoadMyRoomController implements LoadMyRoomsApiSpec {
+
+    private final LoadMyRoomsUseCase loadMyRoomsUseCase;
+
+    @GetMapping("/api/rooms/me")
+    public BaseResponse<FindRoomsResponse> load(
+            @CurrentUser Long userNo
+    ) {
+        return BaseResponse.onSuccess(loadMyRoomsUseCase.execute(userNo));
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/spec/LoadMyRoomsApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/spec/LoadMyRoomsApiSpec.java
@@ -1,0 +1,26 @@
+package com.project.dorumdorum.domain.room.ui.spec;
+
+import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
+import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
+import com.project.dorumdorum.domain.room.domain.entity.RoomType;
+import com.project.dorumdorum.domain.room.domain.entity.Tag;
+import com.project.dorumdorum.global.common.BaseResponse;
+import com.project.dorumdorum.global.pagination.CursorPage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Room")
+public interface LoadMyRoomsApiSpec {
+
+    @Operation(
+            summary = "내가 속한 방 조회 API"
+    )
+    @GetMapping("/api/rooms")
+    BaseResponse<FindRoomsResponse> load(
+            @Parameter(hidden = true) Long userNo
+    );
+}

--- a/src/main/java/com/project/dorumdorum/domain/user/application/dto/request/SignUpRequest.java
+++ b/src/main/java/com/project/dorumdorum/domain/user/application/dto/request/SignUpRequest.java
@@ -10,5 +10,12 @@ public record SignUpRequest(
         @NotBlank String nickname,
         @Email @NotBlank String email,
         @NotBlank String password,
-        @NotNull Gender gender
-) {}
+        @NotBlank String passwordCheck,
+        @NotNull Gender gender,
+        @NotBlank String studentNo
+) {
+    public boolean isCheckedPassword() {
+        return password().equals(passwordCheck());
+    }
+
+}

--- a/src/main/java/com/project/dorumdorum/domain/user/application/usecase/SendVerificationEmailUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/user/application/usecase/SendVerificationEmailUseCase.java
@@ -5,6 +5,7 @@ import com.project.dorumdorum.domain.user.domain.service.UserService;
 import com.project.dorumdorum.global.exception.RestApiException;
 import com.project.dorumdorum.global.util.SecureRandomGenerator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import static com.project.dorumdorum.global.exception.code.status.AuthErrorStatus.INVALID_EMAIL_DOMAIN;

--- a/src/main/java/com/project/dorumdorum/domain/user/application/usecase/SignUpUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/user/application/usecase/SignUpUseCase.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import static com.project.dorumdorum.global.exception.code.status.AuthErrorStatus.ALREADY_REGISTERED_EMAIL;
+import static com.project.dorumdorum.global.exception.code.status.GlobalErrorStatus._PASSWORD_NOT_MATCHES;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +16,9 @@ public class SignUpUseCase {
     private final UserService userService;
 
     public void execute(SignUpRequest request) {
+        if(!request.isCheckedPassword())
+            throw new RestApiException(_PASSWORD_NOT_MATCHES);
+
         if (userService.isAlreadyRegistered(request.email()))
             throw new RestApiException(ALREADY_REGISTERED_EMAIL);
 

--- a/src/main/java/com/project/dorumdorum/domain/user/domain/entity/User.java
+++ b/src/main/java/com/project/dorumdorum/domain/user/domain/entity/User.java
@@ -34,6 +34,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(nullable = false)
+    private String studentNo;
+
     @Enumerated(EnumType.STRING)
     private Gender gender;
 

--- a/src/main/java/com/project/dorumdorum/domain/user/domain/service/EmailVerificationService.java
+++ b/src/main/java/com/project/dorumdorum/domain/user/domain/service/EmailVerificationService.java
@@ -6,6 +6,7 @@ import com.project.dorumdorum.domain.user.infra.smtp.SmtpEmailSender;
 import com.project.dorumdorum.global.exception.RestApiException;
 import com.project.dorumdorum.global.properties.IncludeEmailDomainProperties;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import static com.project.dorumdorum.global.exception.code.status.AuthErrorStatus.FAILED_EMAIL_VERIFICATION;
@@ -23,6 +24,7 @@ public class EmailVerificationService {
         return includeEmailDomainProperties.matches(domain);
     }
 
+    @Async
     public void sendCode(String email, String code) {
         verificationCodeRepository.save(email, code);
         var template = EmailTemplateHelper.generate(code);

--- a/src/main/java/com/project/dorumdorum/domain/user/domain/service/UserService.java
+++ b/src/main/java/com/project/dorumdorum/domain/user/domain/service/UserService.java
@@ -36,6 +36,7 @@ public class UserService {
                         .password(passwordEncoder.encode(request.password()))
                         .role(Role.USER)
                         .gender(request.gender())
+                        .studentNo(request.studentNo())
                         .build()
         );
     }

--- a/src/main/java/com/project/dorumdorum/global/exception/code/status/GlobalErrorStatus.java
+++ b/src/main/java/com/project/dorumdorum/global/exception/code/status/GlobalErrorStatus.java
@@ -20,7 +20,8 @@ public enum GlobalErrorStatus implements BaseCodeInterface {
     _CONTAIN_BAD_WORD(HttpStatus.BAD_REQUEST, "COMMON400", "입력하신 내용에 부적절한 단어가 포함되어 있습니다."),
     _EXIST_ENTITY(HttpStatus.BAD_REQUEST, "COMMON400", "이미 존재하는 요청입니다."),
     _TOO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "COMMON429", "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
-    _PATIENT_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMON400", "존재하지 않는 환자 코드입니다."),
+    _PASSWORD_NOT_MATCHES(HttpStatus.BAD_REQUEST, "COMMON400", "비밀번호가 일치하지 않습니다."),
+
 
     // S3 관련 에러
     _S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3_5001", "파일 업로드에 실패했습니다."),

--- a/src/main/java/com/project/dorumdorum/global/exception/code/status/GlobalErrorStatus.java
+++ b/src/main/java/com/project/dorumdorum/global/exception/code/status/GlobalErrorStatus.java
@@ -38,11 +38,12 @@ public enum GlobalErrorStatus implements BaseCodeInterface {
     DUPLICATE_JOIN_REQUEST(HttpStatus.BAD_REQUEST, "ROOM002", "이미 전송한 요청입니다."),
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM003", "존재하지 않는 방입니다."),
     COMPLETED_ROOM_EXISTS(HttpStatus.BAD_REQUEST, "ROOM004", "이미 확정된 방이 존재하는 유저입니다."),
+    ALREADY_JOINED_USER(HttpStatus.BAD_REQUEST, "ROOM004", "이미 속한 방이 존재하는 유저입니다."),
     NO_PERMISSION_ON_ROOM(HttpStatus.UNAUTHORIZED, "ROOM005", "권한이 없습니다."),
     ROOM_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM006", "존재하지 않는 요청입니다."),
     ROOM_IS_NOT_FULL(HttpStatus.BAD_REQUEST, "ROOM007", "방이 가득차지 않았습니다."),
     ALREADY_CONFIRM_REQUEST(HttpStatus.BAD_REQUEST, "ROOM008", "이미 처리된 요청입니다."),
-
+    ROOMMATE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM009", "룸메이트를 찾을 수 없습니다."),
 
     // Friend
     FRIEND_SELF_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND001", "요청자와 대상자가 같습니다."),


### PR DESCRIPTION
## 📌 PR 제목

[FEAT] 회원가입·로그인 API 연동 및 내 방 조회 기능 구현

---

## 📢 요약

- 회원가입 API 연동  
- 로그인 API 연동  
- 내 방 조회 기능 구현  

🔗 **연관 이슈**: Resolves #이슈번호

---

## 🚀 PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경
- [ ] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [ ] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## ✅ PR 체크리스트

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다.
- [x] 🔹 기능 테스트 완료
- [ ] 🔹 관련 문서 업데이트 (해당 없음)

---

## 📜 기타

- 이후 인증 플로우 정리하면서 리팩토링 예정
