### PR TITLE
[FEAT] 학사일정 및 공지사항 기능 추가

### DIFF
--- a/src/main/java/com/project/dorumdorum/domain/calendar/application/dto/response/CalendarEventResponse.java
+++ b/src/main/java/com/project/dorumdorum/domain/calendar/application/dto/response/CalendarEventResponse.java
@@ -1,0 +1,9 @@
+package com.project.dorumdorum.domain.calendar.application.dto.response;
+
+import java.time.LocalDate;
+
+public record CalendarEventResponse(
+        LocalDate date,
+        String title
+) {
+}

--- a/src/main/java/com/project/dorumdorum/domain/calendar/application/mapper/CalendarEventMapper.java
+++ b/src/main/java/com/project/dorumdorum/domain/calendar/application/mapper/CalendarEventMapper.java
@@ -1,0 +1,15 @@
+package com.project.dorumdorum.domain.calendar.application.mapper;
+
+import com.project.dorumdorum.domain.calendar.application.dto.response.CalendarEventResponse;
+import com.project.dorumdorum.domain.calendar.domain.entity.CalendarEvent;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface CalendarEventMapper {
+    @Mapping(target = "date", source = "eventDate")
+    CalendarEventResponse toResponse(CalendarEvent event);
+    List<CalendarEventResponse> toResponseList(List<CalendarEvent> events);
+}

--- a/src/main/java/com/project/dorumdorum/domain/calendar/application/usecase/LoadCalendarEventsUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/calendar/application/usecase/LoadCalendarEventsUseCase.java
@@ -1,0 +1,26 @@
+package com.project.dorumdorum.domain.calendar.application.usecase;
+
+import com.project.dorumdorum.domain.calendar.application.dto.response.CalendarEventResponse;
+import com.project.dorumdorum.domain.calendar.application.mapper.CalendarEventMapper;
+import com.project.dorumdorum.domain.calendar.domain.repository.CalendarEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LoadCalendarEventsUseCase {
+
+    private final CalendarEventRepository calendarEventRepository;
+    private final CalendarEventMapper calendarEventMapper;
+
+    public List<CalendarEventResponse> execute(LocalDate startDate, LocalDate endDate) {
+        List<com.project.dorumdorum.domain.calendar.domain.entity.CalendarEvent> events = 
+            calendarEventRepository.findByEventDateBetween(startDate, endDate);
+        return calendarEventMapper.toResponseList(events);
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/calendar/domain/entity/CalendarEvent.java
+++ b/src/main/java/com/project/dorumdorum/domain/calendar/domain/entity/CalendarEvent.java
@@ -1,0 +1,27 @@
+package com.project.dorumdorum.domain.calendar.domain.entity;
+
+import com.project.dorumdorum.global.common.BaseEntity;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "calendar_events")
+public class CalendarEvent extends BaseEntity {
+
+    @Id
+    @Tsid
+    private Long eventNo;
+
+    @Column(nullable = false)
+    private LocalDate eventDate;
+
+    @Column(nullable = false)
+    private String title;
+}

--- a/src/main/java/com/project/dorumdorum/domain/calendar/domain/repository/CalendarEventRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/calendar/domain/repository/CalendarEventRepository.java
@@ -1,0 +1,12 @@
+package com.project.dorumdorum.domain.calendar.domain.repository;
+
+import com.project.dorumdorum.domain.calendar.domain.entity.CalendarEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Long> {
+    List<CalendarEvent> findByEventDateBetween(LocalDate startDate, LocalDate endDate);
+    List<CalendarEvent> findByEventDate(LocalDate eventDate);
+}

--- a/src/main/java/com/project/dorumdorum/domain/calendar/ui/LoadCalendarEventsController.java
+++ b/src/main/java/com/project/dorumdorum/domain/calendar/ui/LoadCalendarEventsController.java
@@ -1,0 +1,33 @@
+package com.project.dorumdorum.domain.calendar.ui;
+
+import com.project.dorumdorum.domain.calendar.application.dto.response.CalendarEventResponse;
+import com.project.dorumdorum.domain.calendar.application.usecase.LoadCalendarEventsUseCase;
+import com.project.dorumdorum.domain.calendar.ui.spec.LoadCalendarEventsApiSpec;
+import com.project.dorumdorum.global.annotation.AccessToken;
+import com.project.dorumdorum.global.common.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class LoadCalendarEventsController implements LoadCalendarEventsApiSpec {
+
+    private final LoadCalendarEventsUseCase loadCalendarEventsUseCase;
+
+    @Override
+    @GetMapping("/api/calendar/events")
+    public BaseResponse<List<CalendarEventResponse>> loadCalendarEvents(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @AccessToken Long userNo
+    ) {
+        List<CalendarEventResponse> events = loadCalendarEventsUseCase.execute(startDate, endDate);
+        return BaseResponse.onSuccess(events);
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/calendar/ui/spec/LoadCalendarEventsApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/calendar/ui/spec/LoadCalendarEventsApiSpec.java
@@ -1,0 +1,28 @@
+package com.project.dorumdorum.domain.calendar.ui.spec;
+
+import com.project.dorumdorum.domain.calendar.application.dto.response.CalendarEventResponse;
+import com.project.dorumdorum.global.annotation.AccessToken;
+import com.project.dorumdorum.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Calendar", description = "기숙사 캘린더 API")
+public interface LoadCalendarEventsApiSpec {
+
+    @Operation(summary = "캘린더 일정 조회", description = "지정된 기간의 기숙사 일정을 조회합니다.")
+    @GetMapping("/api/calendar/events")
+    BaseResponse<List<CalendarEventResponse>> loadCalendarEvents(
+            @Parameter(description = "시작 날짜 (yyyy-MM-dd)", example = "2025-01-01")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @Parameter(description = "종료 날짜 (yyyy-MM-dd)", example = "2025-12-31")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @AccessToken Long userNo
+    );
+}

--- a/src/main/java/com/project/dorumdorum/domain/notice/application/dto/response/NoticeResponse.java
+++ b/src/main/java/com/project/dorumdorum/domain/notice/application/dto/response/NoticeResponse.java
@@ -1,0 +1,12 @@
+package com.project.dorumdorum.domain.notice.application.dto.response;
+
+import java.time.LocalDate;
+
+public record NoticeResponse(
+        Long noticeNo,
+        String title,
+        String content,
+        LocalDate writtenDate,
+        String originalLink
+) {
+}

--- a/src/main/java/com/project/dorumdorum/domain/notice/application/mapper/NoticeMapper.java
+++ b/src/main/java/com/project/dorumdorum/domain/notice/application/mapper/NoticeMapper.java
@@ -1,0 +1,13 @@
+package com.project.dorumdorum.domain.notice.application.mapper;
+
+import com.project.dorumdorum.domain.notice.application.dto.response.NoticeResponse;
+import com.project.dorumdorum.domain.notice.domain.entity.Notice;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface NoticeMapper {
+    NoticeResponse toResponse(Notice notice);
+    List<NoticeResponse> toResponseList(List<Notice> notices);
+}

--- a/src/main/java/com/project/dorumdorum/domain/notice/application/usecase/LoadNoticesUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/notice/application/usecase/LoadNoticesUseCase.java
@@ -1,0 +1,25 @@
+package com.project.dorumdorum.domain.notice.application.usecase;
+
+import com.project.dorumdorum.domain.notice.application.dto.response.NoticeResponse;
+import com.project.dorumdorum.domain.notice.application.mapper.NoticeMapper;
+import com.project.dorumdorum.domain.notice.domain.entity.Notice;
+import com.project.dorumdorum.domain.notice.domain.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LoadNoticesUseCase {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeMapper noticeMapper;
+
+    public List<NoticeResponse> execute() {
+        List<Notice> notices = noticeRepository.findAllByOrderByWrittenDateDesc();
+        return noticeMapper.toResponseList(notices);
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/notice/domain/entity/Notice.java
+++ b/src/main/java/com/project/dorumdorum/domain/notice/domain/entity/Notice.java
@@ -1,0 +1,33 @@
+package com.project.dorumdorum.domain.notice.domain.entity;
+
+import com.project.dorumdorum.global.common.BaseEntity;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "notices")
+public class Notice extends BaseEntity {
+
+    @Id
+    @Tsid
+    private Long noticeNo;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDate writtenDate;
+
+    @Column(nullable = false)
+    private String originalLink;
+}

--- a/src/main/java/com/project/dorumdorum/domain/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/notice/domain/repository/NoticeRepository.java
@@ -1,0 +1,10 @@
+package com.project.dorumdorum.domain.notice.domain.repository;
+
+import com.project.dorumdorum.domain.notice.domain.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findAllByOrderByWrittenDateDesc();
+}

--- a/src/main/java/com/project/dorumdorum/domain/notice/ui/LoadNoticesController.java
+++ b/src/main/java/com/project/dorumdorum/domain/notice/ui/LoadNoticesController.java
@@ -1,0 +1,27 @@
+package com.project.dorumdorum.domain.notice.ui;
+
+import com.project.dorumdorum.domain.notice.application.dto.response.NoticeResponse;
+import com.project.dorumdorum.domain.notice.application.usecase.LoadNoticesUseCase;
+import com.project.dorumdorum.domain.notice.ui.spec.LoadNoticesApiSpec;
+import com.project.dorumdorum.global.annotation.AccessToken;
+import com.project.dorumdorum.global.common.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class LoadNoticesController implements LoadNoticesApiSpec {
+
+    private final LoadNoticesUseCase loadNoticesUseCase;
+
+    @Override
+    public BaseResponse<List<NoticeResponse>> loadNotices(
+            @AccessToken Long userNo
+    ) {
+        List<NoticeResponse> notices = loadNoticesUseCase.execute();
+        return BaseResponse.onSuccess(notices);
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/notice/ui/spec/LoadNoticesApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/notice/ui/spec/LoadNoticesApiSpec.java
@@ -1,0 +1,20 @@
+package com.project.dorumdorum.domain.notice.ui.spec;
+
+import com.project.dorumdorum.domain.notice.application.dto.response.NoticeResponse;
+import com.project.dorumdorum.global.annotation.AccessToken;
+import com.project.dorumdorum.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Tag(name = "Notice", description = "공지사항 API")
+public interface LoadNoticesApiSpec {
+
+    @Operation(summary = "공지사항 조회", description = "모든 공지사항을 작성일 내림차순으로 조회합니다.")
+    @GetMapping("/api/notices")
+    BaseResponse<List<NoticeResponse>> loadNotices(
+            @AccessToken Long userNo
+    );
+}


### PR DESCRIPTION
## 📌 제목
feat: 학사 일정 및 공지사항 기능 추가

---

## 📢 요약
학사 일정과 공지사항을 조회/관리할 수 있는 기능을 추가했습니다.  
사용자가 서비스 내에서 학사 관련 일정을 한 곳에서 확인하고, 공지사항을 통해 중요한 정보를 놓치지 않도록 하기 위함입니다.

🔗 **연관 이슈**: Resolves #이슈번호

---

## 🚀 PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [ ] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## ✅ PR 체크리스트

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [x] 🔹 변경 사항에 대한 기본적인 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 기타
- 학사 일정/공지사항 데이터 구조나 API 스펙에 대해 추가 논의가 필요하다면 코멘트 부탁드립니다.
- 추후 필터링, 검색, 정렬 등 UX 개선 기능을 단계적으로 확장할 계획입니다.