### PR TITLE
[FEAT] 채팅 메시지 Rate Limit 적용 및 AOP 바인딩 버그 수정

### DIFF
--- a/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/SendGroupChatMessageUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/SendGroupChatMessageUseCase.java
@@ -12,6 +12,7 @@ import com.project.dorumdorum.domain.notification.application.event.Notification
 import com.project.dorumdorum.domain.notification.domain.entity.NotificationType;
 import com.project.dorumdorum.domain.user.domain.entity.User;
 import com.project.dorumdorum.domain.user.domain.service.UserService;
+import com.project.dorumdorum.global.ratelimit.RateLimited;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ public class SendGroupChatMessageUseCase {
     private final NotificationRequestPublisher notificationRequestPublisher;
     private final UserService userService;
 
+    @RateLimited(tag = "chat-message", key = "#senderNo + ':' + #chatRoomNo")
     @Transactional
     public void send(String chatRoomNo, String senderNo, String content) {
         ChatRoom chatRoom = chatRoomService.findByChatRoomNo(chatRoomNo);

--- a/src/main/java/com/project/dorumdorum/global/ratelimit/RateLimitAspect.java
+++ b/src/main/java/com/project/dorumdorum/global/ratelimit/RateLimitAspect.java
@@ -30,8 +30,10 @@ public class RateLimitAspect {
     private final ExpressionParser expressionParser = new SpelExpressionParser();
     private final DefaultParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
 
-    @Around("@annotation(rateLimited)")
-    public Object applyRateLimit(ProceedingJoinPoint joinPoint, RateLimited rateLimited) throws Throwable {
+    @Around("@annotation(com.project.dorumdorum.global.ratelimit.RateLimited)")
+    public Object applyRateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        RateLimited rateLimited = method.getAnnotation(RateLimited.class);
         String subjectKey = evaluateKey(joinPoint, rateLimited.key());
         RateLimitRule rule = rateLimitPolicyRegistry.get(rateLimited.tag());
 

--- a/src/main/java/com/project/dorumdorum/global/ratelimit/RateLimitAspect.java
+++ b/src/main/java/com/project/dorumdorum/global/ratelimit/RateLimitAspect.java
@@ -32,6 +32,8 @@ public class RateLimitAspect {
 
     @Around("@annotation(com.project.dorumdorum.global.ratelimit.RateLimited)")
     public Object applyRateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
+        // signature.getMethod()가 추후 인터페이스 추가하면 method.getAnnotation()이 null을 반환할 수도 있음.
+        // 이 경우 AopUtils.getMostSpecificMethod()를 사용해야 함.
         Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
         RateLimited rateLimited = method.getAnnotation(RateLimited.class);
         String subjectKey = evaluateKey(joinPoint, rateLimited.key());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -183,3 +183,7 @@ rate-limit:
       permits-per-window: ${FCM_RATE_LIMIT_PER_WINDOW:20}
       window-millis: ${FCM_RATE_LIMIT_WINDOW_MILLIS:10000}
       ttl-seconds: ${FCM_RATE_LIMIT_TTL_SECONDS:20}
+    chat-message:
+      permits-per-window: ${CHAT_RATE_LIMIT_PER_WINDOW:30}
+      window-millis: ${CHAT_RATE_LIMIT_WINDOW_MILLIS:10000}
+      ttl-seconds: ${CHAT_RATE_LIMIT_TTL_SECONDS:20}

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/SendGroupChatMessageUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/SendGroupChatMessageUseCaseTest.java
@@ -23,6 +23,10 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.project.dorumdorum.global.exception.RestApiException;
+import com.project.dorumdorum.global.exception.code.status.ChatErrorStatus;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -92,6 +96,72 @@ class SendGroupChatMessageUseCaseTest {
         useCase.send("cr-1", "user-1", "hello");
 
         verify(chatMessageService).save(chatRoom, "user-1", "hello", MessageType.TEXT, 0);
+        verify(notificationRequestPublisher, never()).publish(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("채팅방 멤버가 아닌 사용자가 메시지 전송 시 validateMembership을 호출한다")
+    void send_WhenNotMember_CallsValidateMembership() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        ChatRoomMember other = mock(ChatRoomMember.class);
+
+        when(chatRoomService.findByChatRoomNo("cr-1")).thenReturn(chatRoom);
+        when(other.getUserNo()).thenReturn("user-2");
+        when(chatRoomMemberService.findByChatRoom(chatRoom)).thenReturn(List.of(other));
+        doThrow(new RestApiException(ChatErrorStatus.NOT_CHAT_ROOM_MEMBER))
+                .when(chatRoomMemberService).validateMembership(chatRoom, "user-1");
+
+        assertThatThrownBy(() -> useCase.send("cr-1", "user-1", "hello"))
+                .isInstanceOf(RestApiException.class);
+
+        verify(chatRoomMemberService).validateMembership(chatRoom, "user-1");
+        verify(chatMessageService, never()).save(any(), any(), any(), any(), anyInt());
+    }
+
+    @Test
+    @DisplayName("nickname이 null이면 name으로 대체하여 메시지를 전송한다")
+    void send_WhenNicknameIsNull_UsesNameAsFallback() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        ChatMessage message = mock(ChatMessage.class);
+        ChatRoomMember sender = mock(ChatRoomMember.class);
+        ChatRoomMember other = mock(ChatRoomMember.class);
+        User mockUser = mock(User.class);
+
+        when(chatRoom.getChatRoomNo()).thenReturn("cr-1");
+        when(chatRoomService.findByChatRoomNo("cr-1")).thenReturn(chatRoom);
+        when(sender.getUserNo()).thenReturn("user-1");
+        when(other.getUserNo()).thenReturn("user-2");
+        when(chatRoomMemberService.findByChatRoom(chatRoom)).thenReturn(List.of(sender, other));
+        when(chatMessageService.save(chatRoom, "user-1", "hi", MessageType.TEXT, 1)).thenReturn(message);
+        when(message.getMessageNo()).thenReturn("msg-1");
+        when(message.getCreatedAt()).thenReturn(LocalDateTime.now());
+        when(userService.findById("user-1")).thenReturn(mockUser);
+        when(mockUser.getNickname()).thenReturn(null);
+        when(mockUser.getName()).thenReturn("홍길동");
+
+        useCase.send("cr-1", "user-1", "hi");
+
+        verify(notificationRequestPublisher).publish(
+                eq("user-2"), eq("홍길동"), eq("hi"),
+                eq(NotificationType.NEW_MESSAGE_RECEIVED), eq("cr-1"));
+    }
+
+    @Test
+    @DisplayName("메시지 저장 중 예외 발생 시 broadcast와 알림이 발행되지 않는다")
+    void send_WhenSaveThrows_DoesNotBroadcastOrNotify() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        ChatRoomMember sender = mock(ChatRoomMember.class);
+
+        when(chatRoomService.findByChatRoomNo("cr-1")).thenReturn(chatRoom);
+        when(sender.getUserNo()).thenReturn("user-1");
+        when(chatRoomMemberService.findByChatRoom(chatRoom)).thenReturn(List.of(sender));
+        when(chatMessageService.save(any(), any(), any(), any(), anyInt()))
+                .thenThrow(new RuntimeException("DB error"));
+
+        assertThatThrownBy(() -> useCase.send("cr-1", "user-1", "hello"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
         verify(notificationRequestPublisher, never()).publish(any(), any(), any(), any(), any());
     }
 }

--- a/src/test/java/com/project/dorumdorum/global/ratelimit/RateLimitAspectTest.java
+++ b/src/test/java/com/project/dorumdorum/global/ratelimit/RateLimitAspectTest.java
@@ -36,7 +36,6 @@ class RateLimitAspectTest {
         RateLimitAspect aspect = new RateLimitAspect(slidingWindowRateLimiter, rateLimitPolicyRegistry);
         RateLimitRule rule = new RateLimitRule(20L, 10_000L, 20L);
         Method method = Target.class.getMethod("call", String.class);
-        RateLimited rateLimited = method.getAnnotation(RateLimited.class);
 
         when(joinPoint.getSignature()).thenReturn(methodSignature);
         when(methodSignature.getMethod()).thenReturn(method);
@@ -44,7 +43,7 @@ class RateLimitAspectTest {
         when(rateLimitPolicyRegistry.get("fcm")).thenReturn(rule);
         when(slidingWindowRateLimiter.isRateLimited("fcm", "user-1", rule)).thenReturn(true);
 
-        assertThatThrownBy(() -> aspect.applyRateLimit(joinPoint, rateLimited))
+        assertThatThrownBy(() -> aspect.applyRateLimit(joinPoint))
                 .isInstanceOf(RestApiException.class);
 
         verify(joinPoint, never()).proceed();


### PR DESCRIPTION
# 📝 Pull Request Template

## 📌 제목
> [FEAT] 채팅 메시지 Rate Limit 적용 및 AOP 바인딩 버그 수정

---

## 📢 요약
채팅 메시지 전송에 Rate Limit을 적용한다. 사용자가 특정 채팅방에서 10초 내 30회를 초과하여 메시지를 보내면 429 Too Many Requests를 반환한다.

구현 과정에서 기존 RateLimitAspect의 Spring AOP 어노테이션 파라미터 바인딩 방식이 WebSocket STOMP 스레드에서 IllegalStateException을 유발하는 버그를 발견하고 함께 수정했다.

🔗 **연관 이슈**: Resolves #76 

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [x] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">📜 기타</h2><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">변경 파일 요약</h3>

파일 | 변경 내용
-- | --
application.yml | chat-message Rate Limit 정책 추가 (30회/10초, TTL 20초)
SendGroupChatMessageUseCase | @RateLimited 적용, key = #senderNo + ':' + #chatRoomNo
RateLimitAspect | AOP 바인딩 방식 변경 (버그 수정)
SendGroupChatMessageUseCaseTest | 비멤버 전송 / nickname null 폴백 / save 예외 시 broadcast 미발행 테스트 3건 추가
RateLimitAspectTest | 변경된 메서드 시그니처에 맞게 호출 수정
load-test/chat-rate-limit.js | k6 부하 테스트 스크립트 신규 추가



<hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Rate Limit 키 설계</h3><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(31, 31, 31); border-color: rgb(69, 69, 69); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 0px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">rate-limit:chat-message:{senderNo}:{chatRoomNo}
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">senderNo</code> 단독이 아닌 <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">senderNo:chatRoomNo</code> 조합을 키로 사용하여, 채팅방 A에서의 제한이 채팅방 B에 영향을 주지 않도록 채팅방별 독립 제한을 적용했다.</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">RateLimitAspect 버그 수정 상세</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>문제</strong>: 기존 <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">@Around("@annotation(rateLimited)")</code> 방식은 Spring AOP가 pointcut 매칭 시 <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">JoinPointMatch</code> 컨텍스트에 어노테이션 인스턴스를 저장하고 advice 호출 시 주입하는데, WebSocket STOMP 메시지 처리 스레드(<code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">notification-*</code>)에서는 이 컨텍스트가 전파되지 않아 <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">IllegalStateException</code>이 발생했다. FCM은 <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">@EventListener</code> 스레드에서 호출되어 문제가 없었으나, 채팅 메시지를 구현하며 처음 드러났다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>수정</strong>: pointcut에서 파라미터 바인딩을 제거하고 <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">method.getAnnotation(RateLimited.class)</code>로 리플렉션 직접 취득으로 교체했다. 이 방식은 스레드 컨텍스트와 무관하게 동작한다.</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(31, 31, 31); border-color: rgb(69, 69, 69); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-java" style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 0px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">// Before
@Around("@annotation(rateLimited)")
public Object applyRateLimit(ProceedingJoinPoint joinPoint, RateLimited rateLimited)

// After
@Around("@annotation(com.project.dorumdorum.global.ratelimit.RateLimited)")
public Object applyRateLimit(ProceedingJoinPoint joinPoint) {
    RateLimited rateLimited = method.getAnnotation(RateLimited.class); // 리플렉션
</code></pre></div><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">k6 부하 테스트 결과</h3><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(31, 31, 31); border-color: rgb(69, 69, 69); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 0px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">전송 시도:         38개
브로드캐스트 수신: 30건  ← 허용 한도(30회/10초) 정확히 일치
차단:              8건   ← 38 - 30 = 8개 정확히 차단
checks:            4/4 ✅</code></pre></div>