### PR TITLE
[FEAT] 서비스 RDB를 MySQL에서 PostgreSQL로 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 
-    // MySQL
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    // PostgreSQL
+    runtimeOnly 'org.postgresql:postgresql'
 
     // MongoDB
     // implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
@@ -86,7 +86,8 @@ dependencies {
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation 'com.h2database:h2'
+    testImplementation 'org.testcontainers:jdbc:1.19.7'
+    testImplementation 'org.testcontainers:postgresql:1.19.7'
     testImplementation 'org.testcontainers:mongodb:1.19.7'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.7'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,17 @@
 services:
-  mysql:
-    image: mysql:8.0
-    container_name: dorumdorum-mysql
+  postgres:
+    image: postgres:16-alpine
+    container_name: dorumdorum-postgres
     ports:
-      - "3306:3306"
+      - "5432:5432"
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
-      - MYSQL_DATABASE=${MYSQL_DATABASE}
-      - MYSQL_USER=${RDB_USERNAME}
-      - MYSQL_PASSWORD=${RDB_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB:-dorumdorum}
+      - POSTGRES_USER=${RDB_USERNAME}
+      - POSTGRES_PASSWORD=${RDB_PASSWORD}
     volumes:
-      - mysql_data:/var/lib/mysql
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      test: ["CMD-SHELL", "pg_isready -U ${RDB_USERNAME} -d ${POSTGRES_DB:-dorumdorum}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -50,7 +48,7 @@ services:
     volumes:
       - ./firebase-service-account.json:/app/firebase-service-account.json:ro
     depends_on:
-      mysql:
+      postgres:
         condition: service_healthy
       redis:
         condition: service_started
@@ -136,7 +134,7 @@ services:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
       - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
-      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
+      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.postgresql.Driver
     ports:
       - "8079:8080"
     restart: unless-stopped
@@ -180,7 +178,7 @@ services:
       - dorumdorum-net
 
 volumes:
-  mysql_data:
+  postgres_data:
   redis_data:
   prometheus_data:
   grafana_data:

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatMessage.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatMessage.java
@@ -11,7 +11,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Table(
-    indexes = @Index(name = "idx_chat_message_room_created", columnList = "chat_room_no, created_at")
+    indexes = @Index(name = "idx_chat_message_room_created_message", columnList = "chat_room_no, created_at, message_no")
 )
 public class ChatMessage extends BaseEntity {
 

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoom.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoom.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.*;
@@ -14,10 +15,15 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(
-        name = "uk_chat_room_direct",
-        columnNames = {"room_no", "chat_room_type", "applicant_user_no"}
-))
+@Table(
+        indexes = {
+                @Index(name = "idx_chat_room_last_message_at", columnList = "last_message_at")
+        },
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_chat_room_direct",
+                columnNames = {"room_no", "chat_room_type", "applicant_user_no"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoomMember.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoomMember.java
@@ -13,6 +13,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Table(
+    indexes = {
+        @Index(name = "idx_chat_room_member_user_room", columnList = "user_no, chat_room_no")
+    },
     uniqueConstraints = @UniqueConstraint(
         name = "uk_chat_room_member_room_user",
         columnNames = {"chat_room_no", "user_no"}

--- a/src/main/java/com/project/dorumdorum/domain/checklist/application/mapper/RoomRuleMapper.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/application/mapper/RoomRuleMapper.java
@@ -4,6 +4,7 @@ import com.project.dorumdorum.domain.checklist.application.dto.request.CreateRoo
 import com.project.dorumdorum.domain.checklist.application.dto.request.UpdateRoomRuleRequest;
 import com.project.dorumdorum.domain.checklist.application.dto.response.MyRoomRuleResponse;
 import com.project.dorumdorum.domain.checklist.domain.entity.RoomRule;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -12,13 +13,13 @@ import org.mapstruct.MappingTarget;
 public interface RoomRuleMapper {
 
     @Mapping(target = "roomRuleNo", ignore = true)
-    @Mapping(target = "roomNo", source = "roomNo")
+    @Mapping(target = "room", source = "room")
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    RoomRule toRoomRule(String roomNo, CreateRoomRuleRequest request);
+    RoomRule toRoomRule(Room room, CreateRoomRuleRequest request);
 
     @Mapping(target = "roomRuleNo", ignore = true)
-    @Mapping(target = "roomNo", ignore = true)
+    @Mapping(target = "room", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     void updateRoomRule(UpdateRoomRuleRequest request, @MappingTarget RoomRule roomRule);

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/RoomRule.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/RoomRule.java
@@ -7,7 +7,29 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "room_rule")
+@Table(
+        name = "room_rule",
+        indexes = {
+                @Index(name = "idx_room_rule_bedtime", columnList = "bedtime"),
+                @Index(name = "idx_room_rule_wake_up", columnList = "wake_up"),
+                @Index(name = "idx_room_rule_return_home", columnList = "return_home"),
+                @Index(name = "idx_room_rule_return_home_time", columnList = "return_home_time"),
+                @Index(name = "idx_room_rule_cleaning", columnList = "cleaning"),
+                @Index(name = "idx_room_rule_phone_call", columnList = "phone_call"),
+                @Index(name = "idx_room_rule_sleep_light", columnList = "sleep_light"),
+                @Index(name = "idx_room_rule_sleep_habit", columnList = "sleep_habit"),
+                @Index(name = "idx_room_rule_snoring", columnList = "snoring"),
+                @Index(name = "idx_room_rule_shower_time", columnList = "shower_time"),
+                @Index(name = "idx_room_rule_eating", columnList = "eating"),
+                @Index(name = "idx_room_rule_lights_out", columnList = "lights_out"),
+                @Index(name = "idx_room_rule_lights_out_time", columnList = "lights_out_time"),
+                @Index(name = "idx_room_rule_home_visit", columnList = "home_visit"),
+                @Index(name = "idx_room_rule_smoking", columnList = "smoking"),
+                @Index(name = "idx_room_rule_refrigerator", columnList = "refrigerator"),
+                @Index(name = "idx_room_rule_updated_at", columnList = "updated_at"),
+                @Index(name = "uk_room_rule_room_no", columnList = "room_no", unique = true)
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/RoomRule.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/RoomRule.java
@@ -1,5 +1,6 @@
 package com.project.dorumdorum.domain.checklist.domain.entity;
 
+import com.project.dorumdorum.domain.room.domain.entity.Room;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,6 +42,16 @@ public class RoomRule extends ChecklistBase {
     @Column(name = "room_rule_no", updatable = false, nullable = false)
     private String roomRuleNo;
 
-    @Column(name = "room_no", nullable = false, unique = true)
-    private String roomNo;
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "room_no",
+            nullable = false,
+            unique = true,
+            foreignKey = @ForeignKey(name = "fk_room_rule_room")
+    )
+    private Room room;
+
+    public String getRoomNo() {
+        return room == null ? null : room.getRoomNo();
+    }
 }

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/repository/RoomRuleRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/repository/RoomRuleRepository.java
@@ -2,11 +2,14 @@ package com.project.dorumdorum.domain.checklist.domain.repository;
 
 import com.project.dorumdorum.domain.checklist.domain.entity.RoomRule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface RoomRuleRepository extends JpaRepository<RoomRule, String> {
 
-    Optional<RoomRule> findByRoomNo(String roomNo);
+    @Query("select rr from RoomRule rr where rr.room.roomNo = :roomNo")
+    Optional<RoomRule> findByRoomNo(@Param("roomNo") String roomNo);
 
 }

--- a/src/main/java/com/project/dorumdorum/domain/checklist/ui/UpdateRoomRuleController.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/ui/UpdateRoomRuleController.java
@@ -4,6 +4,7 @@ import com.project.dorumdorum.domain.checklist.application.dto.request.UpdateRoo
 import com.project.dorumdorum.domain.checklist.application.usecase.UpdateRoomRuleUseCase;
 import com.project.dorumdorum.domain.checklist.ui.spec.UpdateRoomRuleApiSpec;
 import com.project.dorumdorum.global.annotation.CurrentUser;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,7 @@ public class UpdateRoomRuleController implements UpdateRoomRuleApiSpec {
     public ResponseEntity<Void> update(
             @CurrentUser String userNo,
             @RequestParam String roomNo,
-            @RequestBody UpdateRoomRuleRequest request
+            @Valid @RequestBody UpdateRoomRuleRequest request
     ) {
         updateRoomRuleUseCase.execute(userNo, roomNo, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/project/dorumdorum/domain/checklist/ui/spec/UpdateRoomRuleApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/ui/spec/UpdateRoomRuleApiSpec.java
@@ -2,6 +2,7 @@ package com.project.dorumdorum.domain.checklist.ui.spec;
 
 import com.project.dorumdorum.domain.checklist.application.dto.request.UpdateRoomRuleRequest;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,6 +20,6 @@ public interface UpdateRoomRuleApiSpec {
     ResponseEntity<Void> update(
             @Parameter(hidden = true) String userNo,
             @Parameter(description = "규칙 수정하려는 방 번호") @RequestParam String roomNo,
-            @Parameter(description = "수정할 규칙 정보") @RequestBody UpdateRoomRuleRequest request
+            @Parameter(description = "수정할 규칙 정보") @Valid @RequestBody UpdateRoomRuleRequest request
     );
 }

--- a/src/main/java/com/project/dorumdorum/domain/notice/domain/entity/Notice.java
+++ b/src/main/java/com/project/dorumdorum/domain/notice/domain/entity/Notice.java
@@ -25,7 +25,7 @@ public class Notice extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/project/dorumdorum/domain/notification/domain/entity/Device.java
+++ b/src/main/java/com/project/dorumdorum/domain/notification/domain/entity/Device.java
@@ -5,6 +5,7 @@ import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,7 +18,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@Table(name = "devices")
+@Table(
+        name = "devices",
+        indexes = {
+                @Index(name = "idx_device_user_no", columnList = "user_no"),
+                @Index(name = "idx_device_fcm_token", columnList = "fcm_token"),
+                @Index(name = "uk_device_user_device", columnList = "user_no, device_id", unique = true)
+        }
+)
 public class Device extends BaseEntity {
 
     @Id
@@ -40,4 +48,3 @@ public class Device extends BaseEntity {
         this.fcmToken = "";
     }
 }
-

--- a/src/main/java/com/project/dorumdorum/domain/notification/domain/entity/Notification.java
+++ b/src/main/java/com/project/dorumdorum/domain/notification/domain/entity/Notification.java
@@ -12,7 +12,12 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@Table(name = "notifications")
+@Table(
+        name = "notifications",
+        indexes = {
+                @Index(name = "idx_notification_recipient_deleted_created", columnList = "recipient_no, deleted_at, created_at, notification_no")
+        }
+)
 public class Notification extends BaseEntity {
 
     @Id

--- a/src/main/java/com/project/dorumdorum/domain/room/application/dto/request/ChecklistFilterRequest.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/dto/request/ChecklistFilterRequest.java
@@ -1,0 +1,42 @@
+package com.project.dorumdorum.domain.room.application.dto.request;
+
+import com.project.dorumdorum.domain.checklist.domain.entity.enums.*;
+import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
+import com.project.dorumdorum.domain.room.domain.entity.RoomType;
+
+public record ChecklistFilterRequest(
+        SortType sortType,
+        String cursor,
+        RoomType roomType,
+        ResidencePeriod residencePeriod,
+        Integer capacity,
+        String bedtime,
+        String wakeUp,
+        ReturnHomeType returnHome,
+        String returnHomeTime,
+        CleaningType cleaning,
+        PhoneCallType phoneCall,
+        SleepLightType sleepLight,
+        SleepHabitType sleepHabit,
+        SnoringType snoring,
+        ShowerTimeType showerTime,
+        EatingType eating,
+        LightsOutType lightsOut,
+        String lightsOutTime,
+        HomeVisitType homeVisit,
+        SmokingType smoking,
+        RefrigeratorType refrigerator,
+        String hairDryer,
+        AlarmType alarm,
+        EarphoneType earphone,
+        KeyskinType keyskin,
+        HeatType heat,
+        ColdType cold,
+        StudyType study,
+        TrashCanType trashCan
+) {
+    public enum SortType {
+        LATEST,
+        REMAINING
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/room/application/dto/request/ChecklistFilterRequest.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/dto/request/ChecklistFilterRequest.java
@@ -3,9 +3,10 @@ package com.project.dorumdorum.domain.room.application.dto.request;
 import com.project.dorumdorum.domain.checklist.domain.entity.enums.*;
 import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
 import com.project.dorumdorum.domain.room.domain.entity.RoomType;
+import jakarta.validation.constraints.NotNull;
 
 public record ChecklistFilterRequest(
-        SortType sortType,
+        @NotNull SortType sortType,
         String cursor,
         RoomType roomType,
         ResidencePeriod residencePeriod,

--- a/src/main/java/com/project/dorumdorum/domain/room/application/dto/request/RoomCreateRequest.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/dto/request/RoomCreateRequest.java
@@ -3,6 +3,7 @@ package com.project.dorumdorum.domain.room.application.dto.request;
 import com.project.dorumdorum.domain.checklist.application.dto.request.CreateRoomRuleRequest;
 import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
 import com.project.dorumdorum.domain.room.domain.entity.RoomType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -11,5 +12,5 @@ public record RoomCreateRequest(
         @NotNull Integer capacity,
         @NotNull ResidencePeriod residencePeriod,
         @NotBlank String title,
-        @NotNull CreateRoomRuleRequest rule
+        @Valid @NotNull CreateRoomRuleRequest rule
 ) {}

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/CreateRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/CreateRoomUseCase.java
@@ -26,7 +26,7 @@ public class CreateRoomUseCase {
         Room room = roomService.create(userNo, request);
         roommateService.create(userNo, room, RoomRole.HOST);
 
-        RoomRule roomRule = roomRuleMapper.toRoomRule(room.getRoomNo(), request.rule());
+        RoomRule roomRule = roomRuleMapper.toRoomRule(room, request.rule());
         roomRuleService.save(roomRule);
         return room.getRoomNo();
     }

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/FindRoomsUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/FindRoomsUseCase.java
@@ -1,10 +1,7 @@
 package com.project.dorumdorum.domain.room.application.usecase;
 
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
-import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
-import com.project.dorumdorum.domain.room.domain.entity.RoomType;
 import com.project.dorumdorum.domain.room.domain.service.RoomService;
 import com.project.dorumdorum.global.pagination.CursorCodec;
 import com.project.dorumdorum.global.pagination.CursorPage;
@@ -22,18 +19,11 @@ public class FindRoomsUseCase {
     private final RoomService roomService;
     private static final int LIMIT = 50;
 
-    public CursorPage<FindRoomsResponse> execute(
-            RoomRelation relation,
-            List<RoomType> types,
-            List<Integer> capacities,
-            List<ResidencePeriod> residencePeriods,
-            RoomSort sort,
-            String cursor
-    ) {
-        CursorQueryParams params = PaginationHelper.prepareCursorQuery(cursor, LIMIT);
+    public CursorPage<FindRoomsResponse> execute(ChecklistFilterRequest request) {
+        CursorQueryParams params = PaginationHelper.prepareCursorQuery(request.cursor(), LIMIT);
 
         List<FindRoomsResponse> responses = roomService.searchByCursor(
-                relation, types, capacities, residencePeriods, sort,
+                request,
                 params.cursorCreatedAt(),
                 params.cursorId(),
                 params.limitPlusOne()

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/entity/Room.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/entity/Room.java
@@ -10,6 +10,16 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Table(
+        indexes = {
+                @Index(name = "idx_room_status_created", columnList = "room_status, created_at, room_no"),
+                @Index(name = "idx_room_status_remaining_created", columnList = "room_status, remaining, created_at, room_no"),
+                @Index(name = "idx_room_type", columnList = "room_type"),
+                @Index(name = "idx_room_capacity", columnList = "capacity"),
+                @Index(name = "idx_room_residence_period", columnList = "residence_period"),
+                @Index(name = "idx_room_host_user_no", columnList = "host_user_no")
+        }
+)
 public class Room extends BaseEntity {
 
     @Id @Tsid

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/entity/RoomLike.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/entity/RoomLike.java
@@ -10,6 +10,11 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Table(
+        indexes = {
+                @Index(name = "uk_room_like_user_room", columnList = "user_no, room_no", unique = true)
+        }
+)
 public class RoomLike extends BaseEntity {
 
     @Id @Tsid
@@ -22,4 +27,3 @@ public class RoomLike extends BaseEntity {
     @Column(nullable = false)
     private String userNo;
 }
-

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/entity/RoomRequest.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/entity/RoomRequest.java
@@ -10,6 +10,12 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Table(
+        indexes = {
+                @Index(name = "idx_room_request_room_created", columnList = "room_no, created_at"),
+                @Index(name = "idx_room_request_user_room_direction", columnList = "user_no, room_no, direction")
+        }
+)
 public class RoomRequest extends BaseEntity {
 
     @Id @Tsid

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomQueryRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomQueryRepository.java
@@ -1,10 +1,7 @@
 package com.project.dorumdorum.domain.room.domain.repository;
 
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
-import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
-import com.project.dorumdorum.domain.room.domain.entity.RoomType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,17 +9,16 @@ import java.util.Optional;
 
 public interface RoomQueryRepository {
 
-    List<FindRoomsResponse> findByCursor(RoomRelation relation, List<RoomType> types, List<Integer> capacities, List<ResidencePeriod> residencePeriods, RoomSort sort, LocalDateTime cursorCreatedAt, String cursorId, int limitPlusOne);
+    List<FindRoomsResponse> findByCursor(
+            ChecklistFilterRequest request,
+            LocalDateTime cursorCreatedAt,
+            String cursorId,
+            int limitPlusOne
+    );
 
     Optional<FindRoomsResponse> findMyRoom(String userNo);
 
-    /**
-     * 사용자가 관심(좋아요) 표시한 방 목록을 조회한다.
-     */
     List<FindRoomsResponse> findLikedRooms(String userNo);
 
-    /**
-     * 사용자가 지원한 방(RoomRequest.USER_TO_ROOM) 목록을 조회한다.
-     */
     List<FindRoomsResponse> findAppliedRooms(String userNo);
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
@@ -1,12 +1,9 @@
 package com.project.dorumdorum.domain.room.domain.service;
 
 import com.project.dorumdorum.domain.room.application.dto.request.RoomCreateRequest;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
-import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
 import com.project.dorumdorum.domain.room.domain.entity.Room;
-import com.project.dorumdorum.domain.room.domain.entity.RoomType;
 import com.project.dorumdorum.domain.room.domain.repository.RoomRepository;
 import com.project.dorumdorum.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
@@ -41,8 +38,13 @@ public class RoomService {
                 .orElseThrow(() -> new RestApiException(_NOT_FOUND));
     }
 
-    public List<FindRoomsResponse> searchByCursor(RoomRelation relation, List<RoomType> types, List<Integer> capacities, List<ResidencePeriod> residencePeriods, RoomSort sort, LocalDateTime cursorCreatedAt, String cursorId, int limitPlusOne) {
-        return roomRepository.findByCursor(relation, types, capacities, residencePeriods, sort, cursorCreatedAt, cursorId, limitPlusOne);
+    public List<FindRoomsResponse> searchByCursor(
+            ChecklistFilterRequest request,
+            LocalDateTime cursorCreatedAt,
+            String cursorId,
+            int limitPlusOne
+    ) {
+        return roomRepository.findByCursor(request, cursorCreatedAt, cursorId, limitPlusOne);
     }
 
     public FindRoomsResponse findMyRoom(String userNo) {

--- a/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
@@ -53,7 +53,7 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                         )
                 )
                 .from(room)
-                .leftJoin(roomRule).on(roomRule.roomNo.eq(room.roomNo))
+                .leftJoin(roomRule).on(roomRule.room.eq(room))
                 .leftJoin(user).on(user.userNo.eq(room.hostUserNo))
                 .where(
                         room.roomStatus.eq(RoomStatus.CONFIRM_PENDING),

--- a/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
@@ -1,12 +1,10 @@
 package com.project.dorumdorum.domain.room.infra.repository;
 
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.checklist.domain.entity.QRoomRule;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
 import com.project.dorumdorum.domain.room.domain.entity.Direction;
-import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
 import com.project.dorumdorum.domain.room.domain.entity.RoomStatus;
-import com.project.dorumdorum.domain.room.domain.entity.RoomType;
 import com.project.dorumdorum.domain.room.domain.repository.RoomQueryRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
@@ -31,16 +29,15 @@ import static com.querydsl.core.types.Projections.constructor;
 public class RoomRepositoryImpl implements RoomQueryRepository {
 
     private final JPAQueryFactory query;
+    private static final QRoomRule roomRule = QRoomRule.roomRule;
 
     @Override
-    public List<FindRoomsResponse> findByCursor(RoomRelation relation,
-                                                List<RoomType> types,
-                                                List<Integer> capacities,
-                                                List<ResidencePeriod> residencePeriods,
-                                                RoomSort sort,
-                                                LocalDateTime cursorCreatedAt,
-                                                String cursorId,
-                                                int limitPlusOne) {
+    public List<FindRoomsResponse> findByCursor(
+            ChecklistFilterRequest request,
+            LocalDateTime cursorCreatedAt,
+            String cursorId,
+            int limitPlusOne
+    ) {
         JPAQuery<FindRoomsResponse> q = query
                 .select(
                         constructor(FindRoomsResponse.class,
@@ -56,16 +53,41 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                         )
                 )
                 .from(room)
+                .leftJoin(roomRule).on(roomRule.roomNo.eq(room.roomNo))
                 .leftJoin(user).on(user.userNo.eq(room.hostUserNo))
                 .where(
                         room.roomStatus.eq(RoomStatus.CONFIRM_PENDING),
-                        types == null || types.isEmpty() ? null : room.roomType.in(types),
-                        capacities == null || capacities.isEmpty() ? null : room.capacity.in(capacities),
-                        residencePeriods == null || residencePeriods.isEmpty() ? null : room.residencePeriod.in(residencePeriods),
+                        eqRoomType(request),
+                        eqResidencePeriod(request),
+                        eqCapacity(request),
+                        eqBedtime(request),
+                        eqWakeUp(request),
+                        eqReturnHome(request),
+                        eqReturnHomeTime(request),
+                        eqCleaning(request),
+                        eqPhoneCall(request),
+                        eqSleepLight(request),
+                        eqSleepHabit(request),
+                        eqSnoring(request),
+                        eqShowerTime(request),
+                        eqEating(request),
+                        eqLightsOut(request),
+                        eqLightsOutTime(request),
+                        eqHomeVisit(request),
+                        eqSmoking(request),
+                        eqRefrigerator(request),
+                        eqHairDryer(request),
+                        eqAlarm(request),
+                        eqEarphone(request),
+                        eqKeyskin(request),
+                        eqHeat(request),
+                        eqCold(request),
+                        eqStudy(request),
+                        eqTrashCan(request),
                         cursorPredicate(cursorCreatedAt, cursorId)
                 );
 
-        if (sort == RoomSort.REMAINING) {
+        if (request.sortType() == ChecklistFilterRequest.SortType.REMAINING) {
             q.orderBy(room.remaining.asc(), room.createdAt.desc(), room.roomNo.desc());
         } else {
             q.orderBy(room.createdAt.desc(), room.roomNo.desc());
@@ -164,5 +186,117 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
         if (cursorCreatedAt == null || cursorId == null) return null;
         return room.createdAt.lt(cursorCreatedAt)
                 .or(room.createdAt.eq(cursorCreatedAt).and(room.roomNo.lt(cursorId)));
+    }
+
+    private BooleanExpression eqRoomType(ChecklistFilterRequest request) {
+        return request.roomType() == null ? null : room.roomType.eq(request.roomType());
+    }
+
+    private BooleanExpression eqResidencePeriod(ChecklistFilterRequest request) {
+        return request.residencePeriod() == null ? null : room.residencePeriod.eq(request.residencePeriod());
+    }
+
+    private BooleanExpression eqCapacity(ChecklistFilterRequest request) {
+        return request.capacity() == null ? null : room.capacity.eq(request.capacity());
+    }
+
+    private BooleanExpression eqBedtime(ChecklistFilterRequest request) {
+        return isBlank(request.bedtime()) ? null : roomRule.bedtime.eq(request.bedtime());
+    }
+
+    private BooleanExpression eqWakeUp(ChecklistFilterRequest request) {
+        return isBlank(request.wakeUp()) ? null : roomRule.wakeUp.eq(request.wakeUp());
+    }
+
+    private BooleanExpression eqReturnHome(ChecklistFilterRequest request) {
+        return request.returnHome() == null ? null : roomRule.returnHome.eq(request.returnHome());
+    }
+
+    private BooleanExpression eqReturnHomeTime(ChecklistFilterRequest request) {
+        return isBlank(request.returnHomeTime()) ? null : roomRule.returnHomeTime.eq(request.returnHomeTime());
+    }
+
+    private BooleanExpression eqCleaning(ChecklistFilterRequest request) {
+        return request.cleaning() == null ? null : roomRule.cleaning.eq(request.cleaning());
+    }
+
+    private BooleanExpression eqPhoneCall(ChecklistFilterRequest request) {
+        return request.phoneCall() == null ? null : roomRule.phoneCall.eq(request.phoneCall());
+    }
+
+    private BooleanExpression eqSleepLight(ChecklistFilterRequest request) {
+        return request.sleepLight() == null ? null : roomRule.sleepLight.eq(request.sleepLight());
+    }
+
+    private BooleanExpression eqSleepHabit(ChecklistFilterRequest request) {
+        return request.sleepHabit() == null ? null : roomRule.sleepHabit.eq(request.sleepHabit());
+    }
+
+    private BooleanExpression eqSnoring(ChecklistFilterRequest request) {
+        return request.snoring() == null ? null : roomRule.snoring.eq(request.snoring());
+    }
+
+    private BooleanExpression eqShowerTime(ChecklistFilterRequest request) {
+        return request.showerTime() == null ? null : roomRule.showerTime.eq(request.showerTime());
+    }
+
+    private BooleanExpression eqEating(ChecklistFilterRequest request) {
+        return request.eating() == null ? null : roomRule.eating.eq(request.eating());
+    }
+
+    private BooleanExpression eqLightsOut(ChecklistFilterRequest request) {
+        return request.lightsOut() == null ? null : roomRule.lightsOut.eq(request.lightsOut());
+    }
+
+    private BooleanExpression eqLightsOutTime(ChecklistFilterRequest request) {
+        return isBlank(request.lightsOutTime()) ? null : roomRule.lightsOutTime.eq(request.lightsOutTime());
+    }
+
+    private BooleanExpression eqHomeVisit(ChecklistFilterRequest request) {
+        return request.homeVisit() == null ? null : roomRule.homeVisit.eq(request.homeVisit());
+    }
+
+    private BooleanExpression eqSmoking(ChecklistFilterRequest request) {
+        return request.smoking() == null ? null : roomRule.smoking.eq(request.smoking());
+    }
+
+    private BooleanExpression eqRefrigerator(ChecklistFilterRequest request) {
+        return request.refrigerator() == null ? null : roomRule.refrigerator.eq(request.refrigerator());
+    }
+
+    private BooleanExpression eqHairDryer(ChecklistFilterRequest request) {
+        return isBlank(request.hairDryer()) ? null : roomRule.hairDryer.eq(request.hairDryer());
+    }
+
+    private BooleanExpression eqAlarm(ChecklistFilterRequest request) {
+        return request.alarm() == null ? null : roomRule.alarm.eq(request.alarm());
+    }
+
+    private BooleanExpression eqEarphone(ChecklistFilterRequest request) {
+        return request.earphone() == null ? null : roomRule.earphone.eq(request.earphone());
+    }
+
+    private BooleanExpression eqKeyskin(ChecklistFilterRequest request) {
+        return request.keyskin() == null ? null : roomRule.keyskin.eq(request.keyskin());
+    }
+
+    private BooleanExpression eqHeat(ChecklistFilterRequest request) {
+        return request.heat() == null ? null : roomRule.heat.eq(request.heat());
+    }
+
+    private BooleanExpression eqCold(ChecklistFilterRequest request) {
+        return request.cold() == null ? null : roomRule.cold.eq(request.cold());
+    }
+
+    private BooleanExpression eqStudy(ChecklistFilterRequest request) {
+        return request.study() == null ? null : roomRule.study.eq(request.study());
+    }
+
+    private BooleanExpression eqTrashCan(ChecklistFilterRequest request) {
+        return request.trashCan() == null ? null : roomRule.trashCan.eq(request.trashCan());
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/FindRoomsController.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/FindRoomsController.java
@@ -1,19 +1,14 @@
 package com.project.dorumdorum.domain.room.ui;
 
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
 import com.project.dorumdorum.domain.room.application.usecase.FindRoomsUseCase;
-import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
-import com.project.dorumdorum.domain.room.domain.entity.RoomType;
 import com.project.dorumdorum.domain.room.ui.spec.FindRoomsApiSpec;
 import org.springframework.http.ResponseEntity;
 import com.project.dorumdorum.global.pagination.CursorPage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,15 +18,8 @@ public class FindRoomsController implements FindRoomsApiSpec {
 
     @Override
     public ResponseEntity<CursorPage<FindRoomsResponse>> loadAll(
-            @RequestParam RoomRelation relation,
-            @RequestParam(required = false) List<RoomType> types,
-            @RequestParam(required = false) List<Integer> capacities,
-            @RequestParam(required = false) List<ResidencePeriod> residencePeriods,
-            @RequestParam(required = false) RoomSort sort,
-            @RequestParam(required = false) String cursor
+            @RequestBody ChecklistFilterRequest request
     ) {
-        return ResponseEntity.ok(findRoomsUseCase.execute(
-                relation, types, capacities, residencePeriods, sort, cursor
-        ));
+        return ResponseEntity.ok(findRoomsUseCase.execute(request));
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/FindRoomsController.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/FindRoomsController.java
@@ -6,6 +6,7 @@ import com.project.dorumdorum.domain.room.application.usecase.FindRoomsUseCase;
 import com.project.dorumdorum.domain.room.ui.spec.FindRoomsApiSpec;
 import org.springframework.http.ResponseEntity;
 import com.project.dorumdorum.global.pagination.CursorPage;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +19,7 @@ public class FindRoomsController implements FindRoomsApiSpec {
 
     @Override
     public ResponseEntity<CursorPage<FindRoomsResponse>> loadAll(
-            @RequestBody ChecklistFilterRequest request
+            @Valid @RequestBody ChecklistFilterRequest request
     ) {
         return ResponseEntity.ok(findRoomsUseCase.execute(request));
     }

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/UpdateRoomTitleController.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/UpdateRoomTitleController.java
@@ -4,6 +4,7 @@ import com.project.dorumdorum.domain.room.application.dto.request.UpdateRoomTitl
 import com.project.dorumdorum.domain.room.application.usecase.UpdateRoomTitleUseCase;
 import com.project.dorumdorum.domain.room.ui.spec.UpdateRoomTitleApiSpec;
 import com.project.dorumdorum.global.annotation.CurrentUser;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,7 @@ public class UpdateRoomTitleController implements UpdateRoomTitleApiSpec {
     public ResponseEntity<Void> update(
             @CurrentUser String userNo,
             @RequestParam String roomNo,
-            @RequestBody UpdateRoomTitleRequest request
+            @Valid @RequestBody UpdateRoomTitleRequest request
     ) {
         updateRoomTitleUseCase.execute(userNo, roomNo, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/spec/FindRoomsApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/spec/FindRoomsApiSpec.java
@@ -3,6 +3,7 @@ package com.project.dorumdorum.domain.room.ui.spec;
 import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
 import com.project.dorumdorum.global.pagination.CursorPage;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,6 +21,6 @@ public interface FindRoomsApiSpec {
     @PostMapping("/api/rooms/search")
     ResponseEntity<CursorPage<FindRoomsResponse>> loadAll(
             @Parameter(description = "체크리스트 기반 방 검색 조건", required = true)
-            @RequestBody ChecklistFilterRequest request
+            @Valid @RequestBody ChecklistFilterRequest request
     );
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/spec/FindRoomsApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/spec/FindRoomsApiSpec.java
@@ -1,33 +1,25 @@
 package com.project.dorumdorum.domain.room.ui.spec;
 
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
-import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
-import com.project.dorumdorum.domain.room.domain.entity.RoomType;
 import com.project.dorumdorum.global.pagination.CursorPage;
 import org.springframework.http.ResponseEntity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.springframework.web.bind.annotation.GetMapping;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @io.swagger.v3.oas.annotations.tags.Tag(name = "Room")
 public interface FindRoomsApiSpec {
 
     @Operation(
             summary = "방 목록 조회 API",
-            description = "사용자의 관계, 방 타입, 인원 수, 정렬 조건 등을 기준으로 방 목록을 조회합니다. "
+            description = "체크리스트 및 방 조건을 기준으로 방 목록을 조회합니다. "
                     + "커서 기반 페이지네이션을 지원합니다."
     )
-    @GetMapping("/api/rooms")
+    @PostMapping("/api/rooms/search")
     ResponseEntity<CursorPage<FindRoomsResponse>> loadAll(
-            @Parameter(description = "조회 기준 관계", required = true) RoomRelation relation,
-            @Parameter(description = "방 타입 (복수 선택 가능)") List<RoomType> types,
-            @Parameter(description = "최대 인원 수 필터 (복수 선택 가능)") List<Integer> capacities,
-            @Parameter(description = "거주기간 필터 (복수 선택 가능)") List<ResidencePeriod> residencePeriods,
-            @Parameter(description = "정렬 기준") RoomSort sort,
-            @Parameter(description = "커서 값") String cursor
+            @Parameter(description = "체크리스트 기반 방 검색 조건", required = true)
+            @RequestBody ChecklistFilterRequest request
     );
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/spec/UpdateRoomTitleApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/spec/UpdateRoomTitleApiSpec.java
@@ -1,6 +1,7 @@
 package com.project.dorumdorum.domain.room.ui.spec;
 
 import com.project.dorumdorum.domain.room.application.dto.request.UpdateRoomTitleRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,6 +20,6 @@ public interface UpdateRoomTitleApiSpec {
     ResponseEntity<Void> update(
             @Parameter(hidden = true) String userNo,
             @Parameter(description = "제목을 수정하려는 방 번호") @RequestParam String roomNo,
-            @Parameter(description = "수정할 제목") @RequestBody UpdateRoomTitleRequest request
+            @Parameter(description = "수정할 제목") @Valid @RequestBody UpdateRoomTitleRequest request
     );
 }

--- a/src/main/java/com/project/dorumdorum/domain/roommate/domain/entity/Roommate.java
+++ b/src/main/java/com/project/dorumdorum/domain/roommate/domain/entity/Roommate.java
@@ -11,6 +11,13 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Table(
+        indexes = {
+                @Index(name = "idx_roommate_room_no", columnList = "room_no"),
+                @Index(name = "idx_roommate_user_no", columnList = "user_no"),
+                @Index(name = "uk_roommate_user_room", columnList = "user_no, room_no", unique = true)
+        }
+)
 public class Roommate extends BaseEntity {
 
     @Id @Tsid

--- a/src/main/java/com/project/dorumdorum/domain/user/domain/entity/User.java
+++ b/src/main/java/com/project/dorumdorum/domain/user/domain/entity/User.java
@@ -11,7 +11,12 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "users")
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_user_email", columnList = "email")
+        }
+)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,16 +1,16 @@
 spring:
   datasource:
-    username: ${RDB_USERNAME:root}
-    url: ${RDB_URL:jdbc:mysql://localhost:3306/dorumdorum?useUnicode=true&characterEncoding=UTF-8&connectionCollation=utf8mb4_unicode_ci&serverTimezone=UTC}
-    password: ${RDB_PASSWORD:}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${RDB_USERNAME:postgres}
+    url: ${RDB_URL:jdbc:postgresql://localhost:5432/dorumdorum}
+    password: ${RDB_PASSWORD:1234}
+    driver-class-name: org.postgresql.Driver
   data:
     redis:
       host: localhost
       port: 6379
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: true
 
 jwt:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,7 +11,7 @@ spring:
     username: ${RDB_USERNAME}
     url: ${RDB_URL}
     password: ${RDB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.postgresql.Driver
   data:
     redis:
       host: ${REDIS_HOST}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,10 +4,10 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.postgresql.Driver
   jpa:
-    database: mysql
-    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
 
   mail:

--- a/src/test/java/com/project/dorumdorum/domain/checklist/unit/mapper/RoomRuleMapperTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/checklist/unit/mapper/RoomRuleMapperTest.java
@@ -7,6 +7,7 @@ import com.project.dorumdorum.domain.checklist.application.mapper.RoomRuleMapper
 import com.project.dorumdorum.domain.checklist.application.mapper.RoomRuleMapperImpl;
 import com.project.dorumdorum.domain.checklist.domain.entity.RoomRule;
 import com.project.dorumdorum.domain.checklist.unit.ChecklistFixtures;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,11 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RoomRuleMapperTest {
 
     private final RoomRuleMapper mapper = new RoomRuleMapperImpl();
+    private final Room room = Room.builder().roomNo("r1").build();
 
     @Test
     void toRoomRule_MapsRequestToEntity() {
         CreateRoomRuleRequest request = ChecklistFixtures.createRoomRuleRequest();
-        RoomRule entity = mapper.toRoomRule("r1", request);
+        RoomRule entity = mapper.toRoomRule(room, request);
 
         assertThat(entity.getRoomNo()).isEqualTo("r1");
         assertThat(entity.getBedtime()).isEqualTo(request.bedtime());
@@ -29,7 +31,7 @@ class RoomRuleMapperTest {
 
     @Test
     void updateRoomRule_UpdatesTarget() {
-        RoomRule target = mapper.toRoomRule("r1", ChecklistFixtures.createRoomRuleRequest());
+        RoomRule target = mapper.toRoomRule(room, ChecklistFixtures.createRoomRuleRequest());
         UpdateRoomRuleRequest request = ChecklistFixtures.updateRoomRuleRequest();
         String bedtimeBefore = target.getBedtime();
         String notesBefore = target.getOtherNotes();
@@ -43,7 +45,7 @@ class RoomRuleMapperTest {
 
     @Test
     void toResponse_MapsEntityToResponse() {
-        RoomRule entity = mapper.toRoomRule("r1", ChecklistFixtures.createRoomRuleRequest());
+        RoomRule entity = mapper.toRoomRule(room, ChecklistFixtures.createRoomRuleRequest());
 
         MyRoomRuleResponse response = mapper.toResponse(entity);
 
@@ -54,7 +56,7 @@ class RoomRuleMapperTest {
 
     @Test
     void nullInputs_ReturnNull() {
-        assertThat(mapper.toRoomRule("r1", null)).isNotNull();
+        assertThat(mapper.toRoomRule(room, null)).isNotNull();
         assertThat(mapper.toRoomRule(null, null)).isNull();
         assertThat(mapper.toRoomRule(null, ChecklistFixtures.createRoomRuleRequest())).isNotNull();
         assertThat(mapper.toResponse(null)).isNull();
@@ -62,7 +64,7 @@ class RoomRuleMapperTest {
 
     @Test
     void updateRoomRule_WhenRequestNull_DoesNothing() {
-        RoomRule target = mapper.toRoomRule("r1", ChecklistFixtures.createRoomRuleRequest());
+        RoomRule target = mapper.toRoomRule(room, ChecklistFixtures.createRoomRuleRequest());
         String before = target.getBedtime();
 
         mapper.updateRoomRule(null, target);

--- a/src/test/java/com/project/dorumdorum/domain/checklist/unit/service/RoomRuleServiceTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/checklist/unit/service/RoomRuleServiceTest.java
@@ -3,6 +3,7 @@ package com.project.dorumdorum.domain.checklist.unit.service;
 import com.project.dorumdorum.domain.checklist.domain.entity.RoomRule;
 import com.project.dorumdorum.domain.checklist.domain.repository.RoomRuleRepository;
 import com.project.dorumdorum.domain.checklist.domain.service.RoomRuleService;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
 import com.project.dorumdorum.global.exception.RestApiException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,14 +27,14 @@ class RoomRuleServiceTest {
 
     @Test
     void save_ReturnsSavedRule() {
-        RoomRule roomRule = RoomRule.builder().roomNo("r1").build();
+        RoomRule roomRule = RoomRule.builder().room(Room.builder().roomNo("r1").build()).build();
         when(roomRuleRepository.save(roomRule)).thenReturn(roomRule);
         assertThat(service.save(roomRule)).isEqualTo(roomRule);
     }
 
     @Test
     void findByRoomNo_WhenExists_ReturnsRule() {
-        RoomRule roomRule = RoomRule.builder().roomNo("r1").build();
+        RoomRule roomRule = RoomRule.builder().room(Room.builder().roomNo("r1").build()).build();
         when(roomRuleRepository.findByRoomNo("r1")).thenReturn(Optional.of(roomRule));
         assertThat(service.findByRoomNo("r1")).isEqualTo(roomRule);
     }

--- a/src/test/java/com/project/dorumdorum/domain/checklist/unit/usecase/LoadMyRoomRuleUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/checklist/unit/usecase/LoadMyRoomRuleUseCaseTest.java
@@ -5,6 +5,7 @@ import com.project.dorumdorum.domain.checklist.application.mapper.RoomRuleMapper
 import com.project.dorumdorum.domain.checklist.application.usecase.LoadMyRoomRuleUseCase;
 import com.project.dorumdorum.domain.checklist.domain.entity.RoomRule;
 import com.project.dorumdorum.domain.checklist.domain.service.RoomRuleService;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +27,7 @@ class LoadMyRoomRuleUseCaseTest {
 
     @Test
     void execute_LoadsAndMapsRoomRule() {
-        RoomRule roomRule = RoomRule.builder().roomNo("r1").build();
+        RoomRule roomRule = RoomRule.builder().room(Room.builder().roomNo("r1").build()).build();
         MyRoomRuleResponse response = MyRoomRuleResponse.builder().bedtime("23:00").build();
         when(roomRuleService.findByRoomNo("r1")).thenReturn(roomRule);
         when(roomRuleMapper.toResponse(roomRule)).thenReturn(response);

--- a/src/test/java/com/project/dorumdorum/domain/checklist/unit/usecase/UpdateRoomRuleUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/checklist/unit/usecase/UpdateRoomRuleUseCaseTest.java
@@ -34,7 +34,7 @@ class UpdateRoomRuleUseCaseTest {
     void execute_WhenHost_UpdatesRoomAndRule() {
         UpdateRoomRuleRequest request = ChecklistFixtures.updateRoomRuleRequest();
         Room room = mock(Room.class);
-        RoomRule roomRule = RoomRule.builder().roomNo("r1").build();
+        RoomRule roomRule = RoomRule.builder().room(Room.builder().roomNo("r1").build()).build();
         when(roomService.findById("r1")).thenReturn(room);
         when(roommateService.isHost("u1", room)).thenReturn(true);
         when(roomRuleService.findByRoomNo("r1")).thenReturn(roomRule);

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/infra/repository/RoomRepositoryImplTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/infra/repository/RoomRepositoryImplTest.java
@@ -1,6 +1,6 @@
 package com.project.dorumdorum.domain.room.unit.infra.repository;
 
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
 import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
@@ -31,25 +31,13 @@ class RoomRepositoryImplTest {
 
     @Mock private JPAQueryFactory queryFactory;
 
-    @SuppressWarnings("unchecked")
-    @Test
-    @DisplayName("Should return empty list when relation is not recruiting")
-    void findByCursor_WhenRelationNotRecruiting_ReturnsEmpty() {
-        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory);
-        JPAQuery<FindRoomsResponse> jpaQuery = mock(JPAQuery.class, RETURNS_SELF);
-
-        when(queryFactory.select(any(Expression.class))).thenReturn(jpaQuery);
-        when(jpaQuery.fetch()).thenReturn(List.of());
-
-        List<FindRoomsResponse> result = repository.findByCursor(
-                RoomRelation.APPLIED, null, null, null,
-                RoomSort.CREATED_AT, null, null, 10
+    private ChecklistFilterRequest request(ChecklistFilterRequest.SortType sortType) {
+        return new ChecklistFilterRequest(
+                sortType, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null
         );
-
-        assertThat(result).isEmpty();
-        verify(queryFactory).select(any(Expression.class));
-        verify(jpaQuery).limit(10L);
-        verify(jpaQuery).fetch();
     }
 
     @SuppressWarnings("unchecked")
@@ -67,10 +55,15 @@ class RoomRepositoryImplTest {
         when(jpaQuery.fetch()).thenReturn(expected);
 
         LocalDateTime cursorCreatedAt = LocalDateTime.now();
+        ChecklistFilterRequest request = new ChecklistFilterRequest(
+                ChecklistFilterRequest.SortType.REMAINING, null, RoomType.TYPE_1, ResidencePeriod.SEMESTER, 2,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null
+        );
 
         List<FindRoomsResponse> result = repository.findByCursor(
-                RoomRelation.RECRUITING, List.of(RoomType.TYPE_1), List.of(2), List.of(ResidencePeriod.SEMESTER),
-                RoomSort.REMAINING, cursorCreatedAt, "r1", 51
+                request, cursorCreatedAt, "r1", 51
         );
 
         assertThat(result).isEqualTo(expected);
@@ -89,10 +82,10 @@ class RoomRepositoryImplTest {
         when(jpaQuery.fetch()).thenReturn(List.of());
 
         LocalDateTime cursorCreatedAt = LocalDateTime.now();
+        ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST);
 
         List<FindRoomsResponse> result = repository.findByCursor(
-                RoomRelation.RECRUITING, null, null, null,
-                RoomSort.CREATED_AT, cursorCreatedAt, "r9", 11
+                request, cursorCreatedAt, "r9", 11
         );
 
         assertThat(result).isEmpty();
@@ -108,10 +101,10 @@ class RoomRepositoryImplTest {
 
         when(queryFactory.select(org.mockito.ArgumentMatchers.<Expression<FindRoomsResponse>>any())).thenReturn(jpaQuery);
         when(jpaQuery.fetch()).thenReturn(List.of());
+        ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST);
 
         List<FindRoomsResponse> result = repository.findByCursor(
-                RoomRelation.RECRUITING, List.of(), List.of(), List.of(),
-                RoomSort.CREATED_AT, null, null, 7
+                request, null, null, 7
         );
 
         assertThat(result).isEmpty();
@@ -130,10 +123,10 @@ class RoomRepositoryImplTest {
         when(jpaQuery.fetch()).thenReturn(List.of());
 
         LocalDateTime cursorCreatedAt = LocalDateTime.now();
+        ChecklistFilterRequest request = request(null);
 
         List<FindRoomsResponse> result = repository.findByCursor(
-                RoomRelation.RECRUITING, null, null, null,
-                null, cursorCreatedAt, "r3", 5
+                request, cursorCreatedAt, "r3", 5
         );
 
         assertThat(result).isEmpty();

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/service/RoomServiceTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/service/RoomServiceTest.java
@@ -1,8 +1,7 @@
 package com.project.dorumdorum.domain.room.unit.service;
 
 import com.project.dorumdorum.domain.room.application.dto.request.RoomCreateRequest;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
 import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
 import com.project.dorumdorum.domain.room.domain.entity.Room;
@@ -63,12 +62,17 @@ class RoomServiceTest {
                 new FindRoomsResponse("r1", RoomType.TYPE_1, 2, 1, LocalDateTime.now(),
                         "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name())
         );
-        when(roomRepository.findByCursor(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        ChecklistFilterRequest request = new ChecklistFilterRequest(
+                ChecklistFilterRequest.SortType.LATEST, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null
+        );
+        when(roomRepository.findByCursor(any(), any(), any(), anyInt()))
                 .thenReturn(expected);
 
         List<FindRoomsResponse> result = service.searchByCursor(
-                RoomRelation.RECRUITING, null, null, null,
-                RoomSort.CREATED_AT, null, null, 10
+                request, null, null, 10
         );
 
         assertThat(result).isEqualTo(expected);

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/ui/FindRoomsControllerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/ui/FindRoomsControllerTest.java
@@ -1,7 +1,6 @@
 package com.project.dorumdorum.domain.room.unit.ui;
 
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
 import com.project.dorumdorum.domain.room.application.usecase.FindRoomsUseCase;
 import com.project.dorumdorum.domain.room.ui.FindRoomsController;
@@ -17,7 +16,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,13 +28,19 @@ class FindRoomsControllerTest {
 
     @Test
     void loadAll_ReturnsUseCaseResult() {
+        ChecklistFilterRequest request = new ChecklistFilterRequest(
+                ChecklistFilterRequest.SortType.LATEST, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null
+        );
         CursorPage<FindRoomsResponse> page = new CursorPage<>(List.of(), null, false);
-        when(useCase.execute(RoomRelation.RECRUITING, null, null, null, RoomSort.CREATED_AT, null)).thenReturn(page);
+        when(useCase.execute(request)).thenReturn(page);
 
         ResponseEntity<CursorPage<FindRoomsResponse>> response =
-                controller.loadAll(RoomRelation.RECRUITING, null, null, null, RoomSort.CREATED_AT, null);
+                controller.loadAll(request);
 
-        verify(useCase).execute(RoomRelation.RECRUITING, null, null, null, RoomSort.CREATED_AT, null);
+        verify(useCase).execute(request);
         assertThat(response.getBody()).isEqualTo(page);
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/CreateRoomUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/CreateRoomUseCaseTest.java
@@ -42,13 +42,13 @@ class CreateRoomUseCaseTest {
         RoomRule roomRule = org.mockito.Mockito.mock(RoomRule.class);
 
         when(roomService.create(userNo, request)).thenReturn(room);
-        when(roomRuleMapper.toRoomRule("r1", ruleRequest)).thenReturn(roomRule);
+        when(roomRuleMapper.toRoomRule(room, ruleRequest)).thenReturn(roomRule);
 
         useCase.execute(userNo, request);
 
         verify(roomService).create(userNo, request);
         verify(roommateService).create(userNo, room, RoomRole.HOST);
-        verify(roomRuleMapper).toRoomRule("r1", ruleRequest);
+        verify(roomRuleMapper).toRoomRule(room, ruleRequest);
         verify(roomRuleService).save(roomRule);
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/FindRoomsUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/FindRoomsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.project.dorumdorum.domain.room.unit.usecase;
 
-import com.project.dorumdorum.domain.room.application.dto.request.RoomRelation;
+import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
 import com.project.dorumdorum.domain.room.application.usecase.FindRoomsUseCase;
@@ -37,6 +37,15 @@ class FindRoomsUseCaseTest {
                 "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name());
     }
 
+    private ChecklistFilterRequest request(ChecklistFilterRequest.SortType sortType, String cursor) {
+        return new ChecklistFilterRequest(
+                sortType, cursor, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null
+        );
+    }
+
     @Test
     @DisplayName("Should return hasNext true when responses exceed limit")
     void execute_WhenResponsesExceedLimit_ReturnsHasNextTrue() {
@@ -44,25 +53,27 @@ class FindRoomsUseCaseTest {
         List<FindRoomsResponse> responses = java.util.stream.IntStream.rangeClosed(1, 51)
                 .mapToObj(i -> room("r" + i, 2, 1, now.minusMinutes(i)))
                 .toList();
-        when(roomService.searchByCursor(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST, null);
+        when(roomService.searchByCursor(any(), any(), any(), anyInt()))
                 .thenReturn(responses);
 
-        CursorPage<FindRoomsResponse> result = useCase.execute(RoomRelation.RECRUITING, null, null, null, RoomSort.CREATED_AT, null);
+        CursorPage<FindRoomsResponse> result = useCase.execute(request);
 
         assertThat(result.items()).hasSize(50);
         assertThat(result.hasNext()).isTrue();
         assertThat(result.nextCursor()).isNotBlank();
-        verify(roomService).searchByCursor(any(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(roomService).searchByCursor(any(), any(), any(), anyInt());
     }
 
     @Test
     @DisplayName("Should return hasNext false when responses within limit")
     void execute_WhenResponsesWithinLimit_ReturnsHasNextFalse() {
         List<FindRoomsResponse> responses = List.of(room("r1", 2, 1, LocalDateTime.now()));
-        when(roomService.searchByCursor(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.REMAINING, null);
+        when(roomService.searchByCursor(any(), any(), any(), anyInt()))
                 .thenReturn(responses);
 
-        CursorPage<FindRoomsResponse> result = useCase.execute(RoomRelation.RECRUITING, null, null, null, RoomSort.REMAINING, null);
+        CursorPage<FindRoomsResponse> result = useCase.execute(request);
 
         assertThat(result.items()).hasSize(1);
         assertThat(result.hasNext()).isFalse();
@@ -72,12 +83,11 @@ class FindRoomsUseCaseTest {
     @Test
     @DisplayName("Should return null nextCursor when no response")
     void execute_WhenNoResponse_ReturnsNullCursor() {
-        when(roomService.searchByCursor(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST, null);
+        when(roomService.searchByCursor(any(), any(), any(), anyInt()))
                 .thenReturn(List.of());
 
-        CursorPage<FindRoomsResponse> result = useCase.execute(
-                RoomRelation.RECRUITING, null, null, null, RoomSort.CREATED_AT, null
-        );
+        CursorPage<FindRoomsResponse> result = useCase.execute(request);
 
         assertThat(result.items()).isEmpty();
         assertThat(result.nextCursor()).isNull();
@@ -88,15 +98,14 @@ class FindRoomsUseCaseTest {
     @DisplayName("Should decode cursor when cursor is provided")
     void execute_WithCursor_UsesDecodedCursorPath() {
         List<FindRoomsResponse> responses = List.of(room("r1", 2, 1, LocalDateTime.now()));
-        when(roomService.searchByCursor(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        String cursor = com.project.dorumdorum.global.pagination.CursorCodec.encode(LocalDateTime.now(), "r1");
+        ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST, cursor);
+        when(roomService.searchByCursor(any(), any(), any(), anyInt()))
                 .thenReturn(responses);
 
-        String cursor = com.project.dorumdorum.global.pagination.CursorCodec.encode(LocalDateTime.now(), "r1");
-        CursorPage<FindRoomsResponse> result = useCase.execute(
-                RoomRelation.RECRUITING, null, null, null, RoomSort.CREATED_AT, cursor
-        );
+        CursorPage<FindRoomsResponse> result = useCase.execute(request);
 
         assertThat(result.items()).hasSize(1);
-        verify(roomService).searchByCursor(any(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(roomService).searchByCursor(any(), any(), any(), anyInt());
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,25 +3,23 @@ spring:
     name: dorumdorum
   
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: sa
-    password:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:postgresql:16:///testdb
+    username: test
+    password: test
 
   jpa:
     hibernate:
       ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
     show-sql: false
     open-in-view: false
 
   data:
     mongodb:
-      # Testcontainers가 자동으로 MongoDB URI를 설정함
-      # @DynamicPropertySource를 사용하거나 자동 감지됨
     redis:
       host: localhost
       port: 6379


### PR DESCRIPTION
# 📝 Pull Request Template

## 📌 제목
> [FEAT] 서비스 RDB를 MySQL에서 PostgreSQL로 마이그레이션

---

## 📢 요약
> **변경 사항 및 관련 이슈를 간단하게 설명해주세요.**
> - 서비스 RDB 의존성을 MySQL에서 PostgreSQL 기준으로 전환했습니다.
> - 애플리케이션 설정, 로컬 실행 환경, 테스트 환경을 PostgreSQL 중심으로 맞췄습니다.
> - 방/알림/체크리스트 등 주요 조회 패턴을 기준으로 엔티티 인덱스를 재점검하고 보강했습니다.
> - `RoomRule`는 `room_no` 문자열 참조 대신 `Room` FK 연관관계로 정리해 데이터 정합성을 강화했습니다.

🔗 **연관 이슈**: Resolves #이슈번호

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [x] 🧪 테스트 추가 또는 리팩토링
- [x] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [ ] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 기타
> **리뷰어가 알면 좋을 추가 사항을 적어주세요.**
> - `application.yml`, `application-dev.yml`, `application-prod.yml`, `application-test.yml`을 PostgreSQL 기준으로 변경했습니다.
> - 테스트 환경은 H2 대신 PostgreSQL Testcontainers 기반으로 전환했습니다.
> - `docker-compose.yml`의 로컬 DB도 PostgreSQL로 변경했습니다.
> - MySQL 전용 `LONGTEXT`는 PostgreSQL 호환 `TEXT`로 정리했습니다.
> - 주요 엔티티 인덱스를 실제 조회 패턴 기준으로 재정리했습니다.
> - `RoomRule`는 `Room`과 1:1 FK 연관관계로 변경했고, 조회는 JPQL `findByRoomNo`로 정리했습니다.
> - 현재 로컬 PostgreSQL에 스키마가 없는 경우 `ddl-auto: validate` 때문에 기동 시 테이블 검증 오류가 발생할 수 있습니다. 실제 실행 전 스키마 마이그레이션이 필요합니다.