### PR TITLE
[FIX] 그룹 채팅 퇴장/강퇴 unread 집계 보정 및 테스트 안정화

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Setup Gradle cache
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Ensure Docker is available (Testcontainers)
+        run: |
+          echo ">>> [CI] Checking Docker daemon..."
+          docker info
+
       - name: Run tests
         run: |
           echo ">>> [CI] Running tests..."

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ pinpoint-agent/tools/
 
 ### env ###
 .env
+
+# macOS artefacts
+.DS_Store

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/ChatMessageResponse.java
@@ -9,5 +9,6 @@ public record ChatMessageResponse(
         String senderNickname,
         String content,
         String messageType,
-        LocalDateTime sentAt
+        LocalDateTime sentAt,
+        int unreadCount
 ) {}

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/ChatReadReceiptResponse.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/ChatReadReceiptResponse.java
@@ -1,0 +1,9 @@
+package com.project.dorumdorum.domain.chat.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatReadReceiptResponse(
+        String chatRoomNo,
+        String readerUserNo,
+        LocalDateTime readAt
+) {}

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
@@ -3,6 +3,7 @@ package com.project.dorumdorum.domain.chat.application.event;
 import com.project.dorumdorum.domain.chat.application.dto.response.ChatMessageResponse;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatMessage;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
 import com.project.dorumdorum.domain.chat.domain.entity.MessageType;
 import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
 import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
@@ -16,6 +17,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Component
@@ -40,9 +43,12 @@ public class RoommateKickedEventListener {
     public void handle(RoommateKickedEvent event) {
         chatRoomService.findByRoomNo(event.roomNo()).ifPresent(chatRoom -> {
             if (chatRoomMemberService.isMember(chatRoom, event.kickedUserNo())) {
-                chatRoomMemberService.leave(
-                        chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, event.kickedUserNo())
-                );
+                ChatRoomMember member = chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, event.kickedUserNo());
+                LocalDateTime fromTime = member.getLastReadAt() != null
+                        ? member.getLastReadAt()
+                        : member.getJoinedAt();
+                chatMessageService.decreaseUnreadCount(chatRoom.getChatRoomNo(), fromTime, event.kickedUserNo());
+                chatRoomMemberService.leave(member);
                 User kicked = userService.findById(event.kickedUserNo());
                 String displayName = (kicked.getNickname() != null && !kicked.getNickname().isBlank())
                         ? kicked.getNickname() : kicked.getName();

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
@@ -56,7 +56,7 @@ public class RoommateKickedEventListener {
                 ChatMessage message = chatMessageService.save(chatRoom, "SYSTEM", content, MessageType.SYSTEM, 0);
                 ChatMessageResponse response = new ChatMessageResponse(
                         message.getMessageNo(), chatRoom.getChatRoomNo(),
-                        "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt());
+                        "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt(), message.getUnreadCount());
                 broadcastSafely(chatRoom, response);
             }
         });

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/JoinChatRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/JoinChatRoomUseCase.java
@@ -68,7 +68,7 @@ public class JoinChatRoomUseCase {
             ChatMessage message = chatMessageService.save(chatRoom, "SYSTEM", content, MessageType.SYSTEM, 0);
             ChatMessageResponse response = new ChatMessageResponse(
                     message.getMessageNo(), chatRoom.getChatRoomNo(),
-                    "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt());
+                    "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt(), message.getUnreadCount());
             broadcastSafely(chatRoom, response);
         }
     }

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/LeaveChatRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/LeaveChatRoomUseCase.java
@@ -115,7 +115,7 @@ public class LeaveChatRoomUseCase {
         ChatMessage message = chatMessageService.save(chatRoom, "SYSTEM", content, MessageType.SYSTEM, 0);
         ChatMessageResponse response = new ChatMessageResponse(
                 message.getMessageNo(), chatRoomNo,
-                "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt());
+                "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt(), message.getUnreadCount());
         messagingTemplate.convertAndSend("/topic/chat-room/" + chatRoomNo, response);
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/LeaveChatRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/LeaveChatRoomUseCase.java
@@ -88,6 +88,13 @@ public class LeaveChatRoomUseCase {
             throw new RestApiException(HOST_CANNOT_LEAVE);
         }
 
+        if (memberCount > 1) {
+            LocalDateTime fromTime = member.getLastReadAt() != null
+                    ? member.getLastReadAt()
+                    : member.getJoinedAt();
+            chatMessageService.decreaseUnreadCount(chatRoom.getChatRoomNo(), fromTime, userNo);
+        }
+
         chatRoomMemberService.leave(member);
 
         if (memberCount == 1) {

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/LeaveChatRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/LeaveChatRoomUseCase.java
@@ -20,6 +20,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static com.project.dorumdorum.global.exception.code.status.ChatErrorStatus.HOST_CANNOT_LEAVE;
 
 @Service
@@ -59,6 +61,13 @@ public class LeaveChatRoomUseCase {
 
         if (memberCount > 1 && roommateService.isHost(userNo, room)) {
             throw new RestApiException(HOST_CANNOT_LEAVE);
+        }
+
+        if (memberCount > 1) {
+            LocalDateTime fromTime = member.getLastReadAt() != null
+                    ? member.getLastReadAt()
+                    : member.getJoinedAt();
+            chatMessageService.decreaseUnreadCount(chatRoom.getChatRoomNo(), fromTime, userNo);
         }
 
         chatRoomMemberService.leave(member);

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/MarkChatRoomReadUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/MarkChatRoomReadUseCase.java
@@ -1,10 +1,12 @@
 package com.project.dorumdorum.domain.chat.application.usecase;
 
+import com.project.dorumdorum.domain.chat.application.dto.response.ChatReadReceiptResponse;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
 import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
 import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -15,6 +17,7 @@ public class MarkChatRoomReadUseCase {
 
     private final ChatRoomMemberService chatRoomMemberService;
     private final ChatMessageService chatMessageService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     /**
      * 채팅방 읽음 처리
@@ -31,6 +34,12 @@ public class MarkChatRoomReadUseCase {
                 : member.getJoinedAt();
 
         chatMessageService.decreaseUnreadCount(chatRoomNo, fromTime, userNo);
-        chatRoomMemberService.updateLastReadAt(member, LocalDateTime.now());
+        LocalDateTime readAt = LocalDateTime.now();
+        chatRoomMemberService.updateLastReadAt(member, readAt);
+
+        messagingTemplate.convertAndSend(
+                "/topic/chat-room/" + chatRoomNo + "/read",
+                new ChatReadReceiptResponse(chatRoomNo, userNo, readAt)
+        );
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/SendGroupChatMessageUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/usecase/SendGroupChatMessageUseCase.java
@@ -71,7 +71,8 @@ public class SendGroupChatMessageUseCase {
                 senderNickname,
                 content,
                 MessageType.TEXT.name(),
-                message.getCreatedAt()
+                message.getCreatedAt(),
+                message.getUnreadCount()
         );
         messagingTemplate.convertAndSend("/topic/chat-room/" + chatRoomNo, response);
 

--- a/src/main/java/com/project/dorumdorum/domain/roommate/domain/service/RoommateService.java
+++ b/src/main/java/com/project/dorumdorum/domain/roommate/domain/service/RoommateService.java
@@ -67,6 +67,7 @@ public class RoommateService {
         Roommate roommate = roommateRepository.findByUserNoAndRoomNo(userNo, roomNo)
                 .orElseThrow(() -> new RestApiException(_NOT_FOUND));
         roommateRepository.delete(roommate);
+        roommateRepository.flush();
     }
 
     public List<MyRoommateResponse> findMyRoommates(String userNo) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,7 @@
 spring:
+  devtools:
+    restart:
+      enabled: false
   datasource:
     username: ${RDB_USERNAME:postgres}
     url: ${RDB_URL:jdbc:postgresql://localhost:5432/dorumdorum}

--- a/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatRoomSchemaInitializationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatRoomSchemaInitializationTest.java
@@ -2,6 +2,9 @@ package com.project.dorumdorum.domain.chat.integration;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.project.dorumdorum.testsupport.TestcontainersSupport;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +21,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @DisplayName("ChatRoom schema 초기화 테스트")
 class ChatRoomSchemaInitializationTest {
+
+    @BeforeAll
+    static void requireDocker() {
+        Assumptions.assumeTrue(
+                TestcontainersSupport.isDockerAvailable(),
+                "Docker is required for ChatRoomSchemaInitializationTest"
+        );
+    }
 
     @Autowired
     private JdbcTemplate jdbcTemplate;

--- a/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatRoomSchemaInitializationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatRoomSchemaInitializationTest.java
@@ -25,7 +25,7 @@ class ChatRoomSchemaInitializationTest {
     @BeforeAll
     static void requireDocker() {
         Assumptions.assumeTrue(
-                TestcontainersSupport.isDockerAvailable(),
+                TestcontainersSupport.requireDockerOrSkip("ChatRoomSchemaInitializationTest"),
                 "Docker is required for ChatRoomSchemaInitializationTest"
         );
     }

--- a/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatTransactionAtomicityIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatTransactionAtomicityIntegrationTest.java
@@ -32,8 +32,8 @@ import org.mockito.Mockito;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
@@ -76,8 +76,8 @@ class ChatTransactionAtomicityIntegrationTest {
     }
 
     // ─── Firebase 목 (FileInputStream 오류 방지 — 테스트에서 FCM 사용 안 함) ──
-    @MockBean @SuppressWarnings("unused") private FirebaseApp firebaseApp;
-    @MockBean @SuppressWarnings("unused") private FirebaseMessaging firebaseMessaging;
+    @MockitoBean @SuppressWarnings("unused") private FirebaseApp firebaseApp;
+    @MockitoBean @SuppressWarnings("unused") private FirebaseMessaging firebaseMessaging;
 
     // ─── UseCase ──────────────────────────────────────────────────────────────
     @Autowired private KickRoommateUseCase kickRoommateUseCase;
@@ -89,12 +89,12 @@ class ChatTransactionAtomicityIntegrationTest {
     @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
 
     // ─── External Services (Mocking to isolate behavior) ─────────────────────
-    @MockBean private SimpMessagingTemplate messagingTemplate;
+    @MockitoBean private SimpMessagingTemplate messagingTemplate;
 
     // ─── SpyBean (특정 메서드만 실패 강제 또는 외부 의존 우회) ─────────────
-    @SpyBean private ChatRoomMemberService chatRoomMemberService;
-    @SpyBean private UserService userService;
-    @SpyBean private ChatMessageService chatMessageService;
+    @MockitoSpyBean private ChatRoomMemberService chatRoomMemberService;
+    @MockitoSpyBean private UserService userService;
+    @MockitoSpyBean private ChatMessageService chatMessageService;
 
     // ─── 테스트 픽스처 ────────────────────────────────────────────────────────
     private Room room;

--- a/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatTransactionAtomicityIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatTransactionAtomicityIntegrationTest.java
@@ -19,9 +19,12 @@ import com.project.dorumdorum.domain.roommate.domain.repository.RoommateReposito
 import com.project.dorumdorum.domain.user.domain.entity.Role;
 import com.project.dorumdorum.domain.user.domain.entity.User;
 import com.project.dorumdorum.domain.user.domain.service.UserService;
+import com.project.dorumdorum.testsupport.TestcontainersSupport;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,6 +66,14 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles("test")
 @DisplayName("채팅 트랜잭션 원자성 통합 테스트 (BEFORE_COMMIT)")
 class ChatTransactionAtomicityIntegrationTest {
+
+    @BeforeAll
+    static void requireDocker() {
+        Assumptions.assumeTrue(
+                TestcontainersSupport.isDockerAvailable(),
+                "Docker is required for ChatTransactionAtomicityIntegrationTest"
+        );
+    }
 
     // ─── Firebase 목 (FileInputStream 오류 방지 — 테스트에서 FCM 사용 안 함) ──
     @MockBean @SuppressWarnings("unused") private FirebaseApp firebaseApp;

--- a/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatTransactionAtomicityIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatTransactionAtomicityIntegrationTest.java
@@ -70,7 +70,7 @@ class ChatTransactionAtomicityIntegrationTest {
     @BeforeAll
     static void requireDocker() {
         Assumptions.assumeTrue(
-                TestcontainersSupport.isDockerAvailable(),
+                TestcontainersSupport.requireDockerOrSkip("ChatTransactionAtomicityIntegrationTest"),
                 "Docker is required for ChatTransactionAtomicityIntegrationTest"
         );
     }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/LeaveChatRoomUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/LeaveChatRoomUseCaseTest.java
@@ -221,4 +221,53 @@ class LeaveChatRoomUseCaseTest {
         verify(roomService, never()).findByIdForUpdate(any());
         verify(chatRoomService).delete(chatRoom);
     }
+
+    @Test
+    @DisplayName("DIRECT 채팅방에서 다른 멤버가 있을 때는 unreadCount를 감소시키고 나간다")
+    void execute_WhenDirectChatHasOtherMember_DecreasesUnreadCountBeforeLeave() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        ChatRoomMember member = mock(ChatRoomMember.class);
+        User user = mock(User.class);
+        ChatMessage message = mock(ChatMessage.class);
+
+        LocalDateTime lastReadAt = LocalDateTime.of(2026, 5, 1, 10, 0);
+        when(chatRoomService.findByChatRoomNo("cr-1")).thenReturn(chatRoom);
+        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "u1")).thenReturn(member);
+        when(chatRoomMemberService.countByChatRoom(chatRoom)).thenReturn(2L);
+        when(chatRoom.getChatRoomType()).thenReturn(ChatRoomType.DIRECT);
+        when(chatRoom.getChatRoomNo()).thenReturn("cr-1");
+        when(member.getLastReadAt()).thenReturn(lastReadAt);
+        when(userService.findById("u1")).thenReturn(user);
+        when(user.getNickname()).thenReturn("nick");
+        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0))).thenReturn(message);
+        when(message.getMessageNo()).thenReturn("msg-1");
+        when(message.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        useCase.execute("cr-1", "u1");
+
+        verify(chatMessageService).decreaseUnreadCount("cr-1", lastReadAt, "u1");
+        InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService);
+        inOrder.verify(chatMessageService).decreaseUnreadCount("cr-1", lastReadAt, "u1");
+        inOrder.verify(chatRoomMemberService).leave(member);
+    }
+
+    @Test
+    @DisplayName("DIRECT 채팅방에서 방장은 다른 멤버가 있으면 퇴장할 수 없다")
+    void execute_WhenDirectHostHasOtherMember_ThrowsHostCannotLeave() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        ChatRoomMember member = mock(ChatRoomMember.class);
+
+        when(chatRoomService.findByChatRoomNo("cr-1")).thenReturn(chatRoom);
+        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "u1")).thenReturn(member);
+        when(chatRoomMemberService.countByChatRoom(chatRoom)).thenReturn(2L);
+        when(chatRoom.getChatRoomType()).thenReturn(ChatRoomType.DIRECT);
+        when(chatRoom.getRoomNo()).thenReturn("room-1");
+        when(roommateService.isHostOfRoom("u1", "room-1")).thenReturn(true);
+
+        assertThatThrownBy(() -> useCase.execute("cr-1", "u1"))
+                .isInstanceOf(RestApiException.class);
+
+        verify(chatMessageService, never()).decreaseUnreadCount(any(), any(), any());
+        verify(chatRoomMemberService, never()).leave(any());
+    }
 }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/LeaveChatRoomUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/LeaveChatRoomUseCaseTest.java
@@ -29,6 +29,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import org.mockito.InOrder;
+
 @ExtendWith(MockitoExtension.class)
 @DisplayName("LeaveChatRoomUseCase Unit Tests")
 class LeaveChatRoomUseCaseTest {
@@ -115,6 +117,90 @@ class LeaveChatRoomUseCaseTest {
         verify(room).minusCurrentMate();
         verify(chatRoomService).delete(chatRoom);
         verify(chatMessageService, never()).save(any(), any(), any(), any(), anyInt());
+    }
+
+    @Test
+    @DisplayName("비방장이 퇴장할 때 lastReadAt이 없으면 joinedAt 기준으로 decreaseUnreadCount가 leave() 이전에 호출된다")
+    void execute_WhenNonHostLeaves_DecreasesUnreadCountBeforeLeave() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        ChatRoomMember member = mock(ChatRoomMember.class);
+        Room room = mock(Room.class);
+        User mockUser = mock(User.class);
+        ChatMessage mockMessage = mock(ChatMessage.class);
+
+        LocalDateTime joinedAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+        when(chatRoomService.findByChatRoomNo("cr-1")).thenReturn(chatRoom);
+        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "u1")).thenReturn(member);
+        when(chatRoomMemberService.countByChatRoom(chatRoom)).thenReturn(2L);
+        when(chatRoom.getRoomNo()).thenReturn("room-1");
+        when(chatRoom.getChatRoomType()).thenReturn(ChatRoomType.GROUP);
+        when(chatRoom.getChatRoomNo()).thenReturn("cr-1");
+        when(roomService.findByIdForUpdate("room-1")).thenReturn(room);
+        when(roommateService.isHost("u1", room)).thenReturn(false);
+        when(member.getLastReadAt()).thenReturn(null);
+        when(member.getJoinedAt()).thenReturn(joinedAt);
+        when(userService.findById("u1")).thenReturn(mockUser);
+        when(mockUser.getNickname()).thenReturn("nick1");
+        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0))).thenReturn(mockMessage);
+        when(mockMessage.getMessageNo()).thenReturn("msg-1");
+        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        useCase.execute("cr-1", "u1");
+
+        verify(chatMessageService).decreaseUnreadCount("cr-1", LocalDateTime.of(2026, 1, 1, 0, 0), "u1");
+
+        InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService);
+        inOrder.verify(chatMessageService).decreaseUnreadCount("cr-1", LocalDateTime.of(2026, 1, 1, 0, 0), "u1");
+        inOrder.verify(chatRoomMemberService).leave(member);
+    }
+
+    @Test
+    @DisplayName("마지막 멤버가 퇴장할 때는 decreaseUnreadCount가 호출되지 않는다")
+    void execute_WhenLastMemberLeaves_DoesNotDecreaseUnreadCount() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        ChatRoomMember member = mock(ChatRoomMember.class);
+        Room room = mock(Room.class);
+
+        when(chatRoomService.findByChatRoomNo("cr-1")).thenReturn(chatRoom);
+        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "u1")).thenReturn(member);
+        when(chatRoomMemberService.countByChatRoom(chatRoom)).thenReturn(1L);
+        when(chatRoom.getRoomNo()).thenReturn("room-1");
+        when(chatRoom.getChatRoomType()).thenReturn(ChatRoomType.GROUP);
+        when(roomService.findByIdForUpdate("room-1")).thenReturn(room);
+
+        useCase.execute("cr-1", "u1");
+
+        verify(chatMessageService, never()).decreaseUnreadCount(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("lastReadAt이 있으면 lastReadAt을 fromTime으로 decreaseUnreadCount가 호출된다")
+    void execute_WhenLastReadAtExists_UsesLastReadAtAsFromTime() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        ChatRoomMember member = mock(ChatRoomMember.class);
+        Room room = mock(Room.class);
+        User mockUser = mock(User.class);
+        ChatMessage mockMessage = mock(ChatMessage.class);
+
+        LocalDateTime lastReadAt = LocalDateTime.of(2026, 3, 1, 12, 0);
+        when(chatRoomService.findByChatRoomNo("cr-1")).thenReturn(chatRoom);
+        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "u1")).thenReturn(member);
+        when(chatRoomMemberService.countByChatRoom(chatRoom)).thenReturn(2L);
+        when(chatRoom.getRoomNo()).thenReturn("room-1");
+        when(chatRoom.getChatRoomType()).thenReturn(ChatRoomType.GROUP);
+        when(chatRoom.getChatRoomNo()).thenReturn("cr-1");
+        when(roomService.findByIdForUpdate("room-1")).thenReturn(room);
+        when(roommateService.isHost("u1", room)).thenReturn(false);
+        when(member.getLastReadAt()).thenReturn(lastReadAt);
+        when(userService.findById("u1")).thenReturn(mockUser);
+        when(mockUser.getNickname()).thenReturn("nick1");
+        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0))).thenReturn(mockMessage);
+        when(mockMessage.getMessageNo()).thenReturn("msg-1");
+        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        useCase.execute("cr-1", "u1");
+
+        verify(chatMessageService).decreaseUnreadCount("cr-1", LocalDateTime.of(2026, 3, 1, 12, 0), "u1");
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/MarkChatRoomReadUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/MarkChatRoomReadUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.project.dorumdorum.domain.chat.unit.usecase;
 
+import com.project.dorumdorum.domain.chat.application.dto.response.ChatReadReceiptResponse;
 import com.project.dorumdorum.domain.chat.application.usecase.MarkChatRoomReadUseCase;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
 import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.time.LocalDateTime;
 
@@ -23,6 +25,7 @@ class MarkChatRoomReadUseCaseTest {
 
     @Mock private ChatRoomMemberService chatRoomMemberService;
     @Mock private ChatMessageService chatMessageService;
+    @Mock private SimpMessagingTemplate messagingTemplate;
     @InjectMocks private MarkChatRoomReadUseCase useCase;
 
     @Test
@@ -38,6 +41,7 @@ class MarkChatRoomReadUseCaseTest {
 
         verify(chatMessageService).decreaseUnreadCount("cr-1", lastReadAt, "u1");
         verify(chatRoomMemberService).updateLastReadAt(eq(member), any(LocalDateTime.class));
+        verify(messagingTemplate).convertAndSend(eq("/topic/chat-room/cr-1/read"), any(ChatReadReceiptResponse.class));
     }
 
     @Test
@@ -54,5 +58,6 @@ class MarkChatRoomReadUseCaseTest {
 
         verify(chatMessageService).decreaseUnreadCount("cr-1", joinedAt, "u1");
         verify(chatRoomMemberService).updateLastReadAt(eq(member), any(LocalDateTime.class));
+        verify(messagingTemplate).convertAndSend(eq("/topic/chat-room/cr-1/read"), any(ChatReadReceiptResponse.class));
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoommateKickedEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoommateKickedEventListenerTest.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import org.mockito.InOrder;
+
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RoommateKickedEventListener Unit Tests")
 class RoommateKickedEventListenerTest {
@@ -102,6 +104,30 @@ class RoommateKickedEventListenerTest {
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
 
         verify(chatMessageService).save(eq(chatRoom), eq("SYSTEM"), contains("홍길동"), eq(MessageType.SYSTEM), eq(0));
+    }
+
+    @Test
+    @DisplayName("멤버가 존재하면 decreaseUnreadCount가 leave() 이전에 호출된다")
+    void handle_WhenMemberExists_DecreasesUnreadCountBeforeLeave() {
+        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        User mockUser = mock(User.class);
+        ChatMessage mockMessage = mock(ChatMessage.class);
+        when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
+        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
+        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
+        when(userService.findById("user-kicked")).thenReturn(mockUser);
+        when(mockUser.getNickname()).thenReturn("kickedNick");
+        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0))).thenReturn(mockMessage);
+        when(mockMessage.getMessageNo()).thenReturn("msg-1");
+        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
+
+        verify(chatMessageService).decreaseUnreadCount(any(), any(), eq("user-kicked"));
+
+        InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService);
+        inOrder.verify(chatMessageService).decreaseUnreadCount(any(), any(), eq("user-kicked"));
+        inOrder.verify(chatRoomMemberService).leave(member);
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/testsupport/TestcontainersSupport.java
+++ b/src/test/java/com/project/dorumdorum/testsupport/TestcontainersSupport.java
@@ -1,0 +1,27 @@
+package com.project.dorumdorum.testsupport;
+
+import org.testcontainers.DockerClientFactory;
+
+/**
+ * Utility helpers for integration tests that rely on Testcontainers.
+ */
+public final class TestcontainersSupport {
+
+    private static final boolean DOCKER_AVAILABLE = checkDockerAvailability();
+
+    private TestcontainersSupport() {
+    }
+
+    public static boolean isDockerAvailable() {
+        return DOCKER_AVAILABLE;
+    }
+
+    private static boolean checkDockerAvailability() {
+        try {
+            DockerClientFactory.instance().client();
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/project/dorumdorum/testsupport/TestcontainersSupport.java
+++ b/src/test/java/com/project/dorumdorum/testsupport/TestcontainersSupport.java
@@ -8,12 +8,31 @@ import org.testcontainers.DockerClientFactory;
 public final class TestcontainersSupport {
 
     private static final boolean DOCKER_AVAILABLE = checkDockerAvailability();
+    private static final boolean CI = detectCiEnvironment();
 
     private TestcontainersSupport() {
     }
 
     public static boolean isDockerAvailable() {
         return DOCKER_AVAILABLE;
+    }
+
+    public static boolean isCiEnvironment() {
+        return CI;
+    }
+
+    /**
+     * Returns {@code true} when Docker is ready for use. If Docker is unavailable in CI, throws an
+     * {@link IllegalStateException} so the build fails instead of silently skipping tests.
+     */
+    public static boolean requireDockerOrSkip(String testName) {
+        if (DOCKER_AVAILABLE) {
+            return true;
+        }
+        if (CI) {
+            throw new IllegalStateException("Docker is required for " + testName + " in CI");
+        }
+        return false;
     }
 
     private static boolean checkDockerAvailability() {
@@ -23,5 +42,10 @@ public final class TestcontainersSupport {
         } catch (Throwable ignored) {
             return false;
         }
+    }
+
+    private static boolean detectCiEnvironment() {
+        String ciEnv = System.getenv("CI");
+        return ciEnv != null && Boolean.parseBoolean(ciEnv);
     }
 }


### PR DESCRIPTION
# 📝 Pull Request Template

## 📌 제목
> **그룹 채팅 퇴장/강퇴 unread 집계 보정 및 테스트 안정화**

---

## 📢 요약
> 룸메이트가 그룹 채팅방에서 퇴장하거나 강퇴될 때 미확인 메시지(unreadCount)가 남아 있어 지표가 왜곡되는 문제를 해결했습니다. 함께, Docker가 없는 환경에서도 통합 테스트가 실패하지 않도록 Testcontainers 감지 유틸리티를 추가했습니다.


## 구현/수정 사항

  ### 1. 퇴장/강퇴 시 unreadCount 정합성 보장

  - LeaveChatRoomUseCase / RoommateKickedEventListener에서 ChatRoomMember의 lastReadAt 혹은 joinedAt을 기준으로
    ChatMessageService.decreaseUnreadCount()를 먼저 호출한 뒤 멤버를 삭제하도록 순서를 보장했습니다.
  - 마지막 남은 1인 방에서는 unread 감소가 필요 없으므로 조건부로 실행합니다.
  - 강퇴 이벤트 역시 동일 로직을 공유해, kicked 유저의 모든 미확인 메시지가 즉시 정리됩니다.

  ### 2. 단위 테스트 보강

  - LeaveChatRoomUseCaseTest, RoommateKickedEventListenerTest에 InOrder 검증을 추가해 unread 감소 → leave 순서가 강제
    되는지, lastReadAt/최소 참여 인원 조건이 만족되는지 확인합니다.
  - joinedAt 기반 fall-back, lastReadAt 기반 업데이트 등 주요 분기 모두 테스트했습니다.

  ### 3. Testcontainers 테스트 안정화

  - TestcontainersSupport 헬퍼를 추가해 한 번만 Docker 사용 가능 여부를 감지합니다.
  - ChatRoomSchemaInitializationTest, ChatTransactionAtomicityIntegrationTest의 @BeforeAll에서
    Assumptions.assumeTrue(...)를 호출해 Docker가 없으면 테스트를 자동 스킵하도록 만들었습니다. 로컬/CI에서 Docker가
    있을 때는 기존과 동일하게 실행됩니다.

🔗 **연관 이슈**: Resolves #86 

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [ ] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [x] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [ ] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [ ] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 기타
> **리뷰어가 알면 좋을 추가 사항을 적어주세요.**
> - 기능 개선 아이디어
> - 코드 리팩토링 필요 여부 등