### PR TITLE
[FEAT] 체크리스트 기반 방 필터링 조회 쿼리 최적화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ pinpoint-agent/tools/
 
 ### env ###
 .env
+/analysis/

--- a/src/main/java/com/project/dorumdorum/domain/room/application/dto/response/FindRoomsResponse.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/dto/response/FindRoomsResponse.java
@@ -16,5 +16,6 @@ public record FindRoomsResponse(
         String title,
         String hostNickname,
         RoomStatus roomStatus,
-        String residencePeriod // 거주기간 (예: "학기(16주)", "반기(24주)", "계절학기")
+        String residencePeriod, // 거주기간 (예: "학기(16주)", "반기(24주)", "계절학기")
+        Integer remaining
 ) {}

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/FindRoomsUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/FindRoomsUseCase.java
@@ -9,11 +9,13 @@ import com.project.dorumdorum.global.pagination.CursorQueryParams;
 import com.project.dorumdorum.global.pagination.PaginationHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FindRoomsUseCase {
 
     private final RoomService roomService;
@@ -31,13 +33,16 @@ public class FindRoomsUseCase {
                 request,
                 params.cursorCreatedAt(),
                 params.cursorId(),
+                params.cursorRemaining(),
                 params.limitPlusOne()
         );
 
         return PaginationHelper.buildCursorPage(
                 responses,
                 LIMIT,
-                last -> CursorCodec.encode(last.createdAt(), last.roomNo())
+                last -> request.sortType() == ChecklistFilterRequest.SortType.REMAINING
+                        ? CursorCodec.encode(last.remaining(), last.createdAt(), last.roomNo())
+                        : CursorCodec.encode(last.createdAt(), last.roomNo())
         );
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/entity/Room.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/entity/Room.java
@@ -13,9 +13,7 @@ import lombok.*;
 @Table(
         indexes = {
                 @Index(name = "idx_room_status_created", columnList = "room_status, created_at, room_no"),
-                @Index(name = "idx_room_status_remaining_created", columnList = "room_status, remaining, created_at, room_no"),
-                @Index(name = "idx_room_type", columnList = "room_type"),
-                @Index(name = "idx_room_capacity", columnList = "capacity"),
+                @Index(name = "idx_room_status_remaining_created", columnList = "room_status, remaining, created_at DESC, room_no DESC"),
                 @Index(name = "idx_room_residence_period", columnList = "residence_period"),
                 @Index(name = "idx_room_host_user_no", columnList = "host_user_no")
         }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomQueryRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomQueryRepository.java
@@ -13,6 +13,7 @@ public interface RoomQueryRepository {
             ChecklistFilterRequest request,
             LocalDateTime cursorCreatedAt,
             String cursorId,
+            Integer cursorRemaining,
             int limitPlusOne
     );
 

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
@@ -47,9 +47,10 @@ public class RoomService {
             ChecklistFilterRequest request,
             LocalDateTime cursorCreatedAt,
             String cursorId,
+            Integer cursorRemaining,
             int limitPlusOne
     ) {
-        return roomRepository.findByCursor(request, cursorCreatedAt, cursorId, limitPlusOne);
+        return roomRepository.findByCursor(request, cursorCreatedAt, cursorId, cursorRemaining, limitPlusOne);
     }
 
     public FindRoomsResponse findMyRoom(String userNo) {

--- a/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
@@ -1,20 +1,25 @@
 package com.project.dorumdorum.domain.room.infra.repository;
 
-import com.project.dorumdorum.domain.checklist.domain.entity.QRoomRule;
 import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
 import com.project.dorumdorum.domain.room.domain.entity.Direction;
+import com.project.dorumdorum.domain.room.domain.entity.RoomType;
 import com.project.dorumdorum.domain.room.domain.entity.RoomStatus;
 import com.project.dorumdorum.domain.room.domain.repository.RoomQueryRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.project.dorumdorum.domain.room.domain.entity.QRoom.room;
@@ -29,15 +34,20 @@ import static com.querydsl.core.types.Projections.constructor;
 public class RoomRepositoryImpl implements RoomQueryRepository {
 
     private final JPAQueryFactory query;
-    private static final QRoomRule roomRule = QRoomRule.roomRule;
+    private final EntityManager entityManager;
 
     @Override
     public List<FindRoomsResponse> findByCursor(
             ChecklistFilterRequest request,
             LocalDateTime cursorCreatedAt,
             String cursorId,
+            Integer cursorRemaining,
             int limitPlusOne
     ) {
+        if (hasChecklistFilters(request)) {
+            return findByCursorWithLateral(request, cursorCreatedAt, cursorId, cursorRemaining, limitPlusOne);
+        }
+
         JPAQuery<FindRoomsResponse> q = query
                 .select(
                         constructor(FindRoomsResponse.class,
@@ -49,42 +59,20 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                                 room.title,
                                 user.nickname,
                                 room.roomStatus,
-                                room.residencePeriod.stringValue()
+                                room.residencePeriod.stringValue(),
+                                room.remaining
                         )
                 )
                 .from(room)
-                .leftJoin(roomRule).on(roomRule.room.eq(room))
                 .leftJoin(user).on(user.userNo.eq(room.hostUserNo))
                 .where(
                         room.roomStatus.eq(RoomStatus.CONFIRM_PENDING),
                         eqRoomType(request),
                         eqResidencePeriod(request),
                         eqCapacity(request),
-                        eqBedtime(request),
-                        eqWakeUp(request),
-                        eqReturnHome(request),
-                        eqReturnHomeTime(request),
-                        eqCleaning(request),
-                        eqPhoneCall(request),
-                        eqSleepLight(request),
-                        eqSleepHabit(request),
-                        eqSnoring(request),
-                        eqShowerTime(request),
-                        eqEating(request),
-                        eqLightsOut(request),
-                        eqLightsOutTime(request),
-                        eqHomeVisit(request),
-                        eqSmoking(request),
-                        eqRefrigerator(request),
-                        eqHairDryer(request),
-                        eqAlarm(request),
-                        eqEarphone(request),
-                        eqKeyskin(request),
-                        eqHeat(request),
-                        eqCold(request),
-                        eqStudy(request),
-                        eqTrashCan(request),
-                        cursorPredicate(cursorCreatedAt, cursorId)
+                        request.sortType() == ChecklistFilterRequest.SortType.REMAINING
+                                ? remainingCursorPredicate(cursorRemaining, cursorCreatedAt, cursorId)
+                                : cursorPredicate(cursorCreatedAt, cursorId)
                 );
 
         if (request.sortType() == ChecklistFilterRequest.SortType.REMAINING) {
@@ -94,6 +82,89 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
         }
 
         return q.limit(limitPlusOne).fetch();
+    }
+
+    private List<FindRoomsResponse> findByCursorWithLateral(
+            ChecklistFilterRequest request,
+            LocalDateTime cursorCreatedAt,
+            String cursorId,
+            Integer cursorRemaining,
+            int limitPlusOne
+    ) {
+        StringBuilder sql = new StringBuilder("""
+                SELECT
+                    r.room_no,
+                    r.room_type,
+                    r.capacity,
+                    r.current_mate_count,
+                    r.created_at,
+                    r.title,
+                    u.nickname,
+                    r.room_status,
+                    r.residence_period::text,
+                    r.remaining
+                FROM room r
+                JOIN LATERAL (
+                    SELECT 1
+                    FROM room_rule rr
+                    WHERE rr.room_no = r.room_no
+                """);
+
+        Map<String, Object> params = new LinkedHashMap<>();
+
+        appendCondition(sql, params, "rr.bedtime", "bedtime", request.bedtime());
+        appendCondition(sql, params, "rr.wake_up", "wakeUp", request.wakeUp());
+        appendCondition(sql, params, "rr.return_home", "returnHome", enumName(request.returnHome()));
+        appendCondition(sql, params, "rr.return_home_time", "returnHomeTime", request.returnHomeTime());
+        appendCondition(sql, params, "rr.cleaning", "cleaning", enumName(request.cleaning()));
+        appendCondition(sql, params, "rr.phone_call", "phoneCall", enumName(request.phoneCall()));
+        appendCondition(sql, params, "rr.sleep_light", "sleepLight", enumName(request.sleepLight()));
+        appendCondition(sql, params, "rr.sleep_habit", "sleepHabit", enumName(request.sleepHabit()));
+        appendCondition(sql, params, "rr.snoring", "snoring", enumName(request.snoring()));
+        appendCondition(sql, params, "rr.shower_time", "showerTime", enumName(request.showerTime()));
+        appendCondition(sql, params, "rr.eating", "eating", enumName(request.eating()));
+        appendCondition(sql, params, "rr.lights_out", "lightsOut", enumName(request.lightsOut()));
+        appendCondition(sql, params, "rr.lights_out_time", "lightsOutTime", request.lightsOutTime());
+        appendCondition(sql, params, "rr.home_visit", "homeVisit", enumName(request.homeVisit()));
+        appendCondition(sql, params, "rr.smoking", "smoking", enumName(request.smoking()));
+        appendCondition(sql, params, "rr.refrigerator", "refrigerator", enumName(request.refrigerator()));
+        appendCondition(sql, params, "rr.hair_dryer", "hairDryer", request.hairDryer());
+        appendCondition(sql, params, "rr.alarm", "alarm", enumName(request.alarm()));
+        appendCondition(sql, params, "rr.earphone", "earphone", enumName(request.earphone()));
+        appendCondition(sql, params, "rr.keyskin", "keyskin", enumName(request.keyskin()));
+        appendCondition(sql, params, "rr.heat", "heat", enumName(request.heat()));
+        appendCondition(sql, params, "rr.cold", "cold", enumName(request.cold()));
+        appendCondition(sql, params, "rr.study", "study", enumName(request.study()));
+        appendCondition(sql, params, "rr.trash_can", "trashCan", enumName(request.trashCan()));
+
+        sql.append("""
+                        LIMIT 1
+                    ) rule_match ON TRUE
+                LEFT JOIN users u
+                    ON u.user_no = r.host_user_no
+                WHERE r.room_status = :roomStatus
+                """);
+        params.put("roomStatus", RoomStatus.CONFIRM_PENDING.name());
+
+        appendCondition(sql, params, "r.room_type", "roomType", enumName(request.roomType()));
+        appendCondition(sql, params, "r.residence_period", "residencePeriod", enumName(request.residencePeriod()));
+        appendCondition(sql, params, "r.capacity", "capacity", request.capacity());
+        appendCursorCondition(sql, params, request.sortType(), cursorCreatedAt, cursorId, cursorRemaining);
+
+        sql.append("\n                ORDER BY ");
+        appendOrderBy(sql, "r", request.sortType());
+        sql.append("\n                LIMIT :limitPlusOne");
+        params.put("limitPlusOne", limitPlusOne);
+
+        Query nativeQuery = entityManager.createNativeQuery(sql.toString());
+        params.forEach(nativeQuery::setParameter);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = nativeQuery.getResultList();
+
+        return rows.stream()
+                .map(this::toFindRoomsResponse)
+                .toList();
     }
 
     @Override
@@ -109,7 +180,8 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                                 room.title,
                                 user.nickname,
                                 room.roomStatus,
-                                room.residencePeriod.stringValue()
+                                room.residencePeriod.stringValue(),
+                                room.remaining
                         )
                 )
                 .from(room)
@@ -139,7 +211,8 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                                 room.title,
                                 user.nickname,
                                 room.roomStatus,
-                                room.residencePeriod.stringValue()
+                                room.residencePeriod.stringValue(),
+                                room.remaining
                         )
                 )
                 .from(roomLike)
@@ -166,7 +239,8 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                                 room.title,
                                 user.nickname,
                                 room.roomStatus,
-                                room.residencePeriod.stringValue()
+                                room.residencePeriod.stringValue(),
+                                room.remaining
                         )
                 )
                 .from(roomRequest)
@@ -181,11 +255,17 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                 .fetch();
     }
 
-    /** 커서는 항상 (createdAt, pk). 정렬은 sort 파라미터로 ORDER BY에서만 적용 */
     private BooleanExpression cursorPredicate(LocalDateTime cursorCreatedAt, String cursorId) {
         if (cursorCreatedAt == null || cursorId == null) return null;
         return room.createdAt.lt(cursorCreatedAt)
                 .or(room.createdAt.eq(cursorCreatedAt).and(room.roomNo.lt(cursorId)));
+    }
+
+    private BooleanExpression remainingCursorPredicate(Integer cursorRemaining, LocalDateTime cursorCreatedAt, String cursorId) {
+        if (cursorRemaining == null || cursorCreatedAt == null || cursorId == null) return null;
+        return room.remaining.gt(cursorRemaining)
+                .or(room.remaining.eq(cursorRemaining).and(room.createdAt.lt(cursorCreatedAt)))
+                .or(room.remaining.eq(cursorRemaining).and(room.createdAt.eq(cursorCreatedAt)).and(room.roomNo.lt(cursorId)));
     }
 
     private BooleanExpression eqRoomType(ChecklistFilterRequest request) {
@@ -200,100 +280,144 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
         return request.capacity() == null ? null : room.capacity.eq(request.capacity());
     }
 
-    private BooleanExpression eqBedtime(ChecklistFilterRequest request) {
-        return isBlank(request.bedtime()) ? null : roomRule.bedtime.eq(request.bedtime());
+    private boolean hasChecklistFilters(ChecklistFilterRequest request) {
+        return !isBlank(request.bedtime())
+                || !isBlank(request.wakeUp())
+                || request.returnHome() != null
+                || !isBlank(request.returnHomeTime())
+                || request.cleaning() != null
+                || request.phoneCall() != null
+                || request.sleepLight() != null
+                || request.sleepHabit() != null
+                || request.snoring() != null
+                || request.showerTime() != null
+                || request.eating() != null
+                || request.lightsOut() != null
+                || !isBlank(request.lightsOutTime())
+                || request.homeVisit() != null
+                || request.smoking() != null
+                || request.refrigerator() != null
+                || !isBlank(request.hairDryer())
+                || request.alarm() != null
+                || request.earphone() != null
+                || request.keyskin() != null
+                || request.heat() != null
+                || request.cold() != null
+                || request.study() != null
+                || request.trashCan() != null;
     }
 
-    private BooleanExpression eqWakeUp(ChecklistFilterRequest request) {
-        return isBlank(request.wakeUp()) ? null : roomRule.wakeUp.eq(request.wakeUp());
+    private void appendCondition(
+            StringBuilder sql,
+            Map<String, Object> params,
+            String column,
+            String parameterName,
+            Object value
+    ) {
+        if (value == null || (value instanceof String stringValue && isBlank(stringValue))) {
+            return;
+        }
+
+        sql.append("\n          AND ").append(column).append(" = :").append(parameterName);
+        params.put(parameterName, value);
     }
 
-    private BooleanExpression eqReturnHome(ChecklistFilterRequest request) {
-        return request.returnHome() == null ? null : roomRule.returnHome.eq(request.returnHome());
+    private void appendCursorCondition(
+            StringBuilder sql,
+            Map<String, Object> params,
+            ChecklistFilterRequest.SortType sortType,
+            LocalDateTime cursorCreatedAt,
+            String cursorId,
+            Integer cursorRemaining
+    ) {
+        if (sortType == ChecklistFilterRequest.SortType.REMAINING) {
+            if (cursorRemaining == null || cursorCreatedAt == null || cursorId == null) {
+                return;
+            }
+
+            sql.append("""
+                    
+                      AND (
+                          r.remaining > :cursorRemaining
+                          OR (r.remaining = :cursorRemaining AND r.created_at < :cursorCreatedAt)
+                          OR (r.remaining = :cursorRemaining AND r.created_at = :cursorCreatedAt AND r.room_no < :cursorId)
+                      )
+                    """);
+            params.put("cursorRemaining", cursorRemaining);
+            params.put("cursorCreatedAt", cursorCreatedAt);
+            params.put("cursorId", cursorId);
+            return;
+        }
+
+        if (cursorCreatedAt == null || cursorId == null) {
+            return;
+        }
+
+        sql.append("""
+                
+                  AND (
+                      r.created_at < :cursorCreatedAt
+                      OR (r.created_at = :cursorCreatedAt AND r.room_no < :cursorId)
+                  )
+                """);
+        params.put("cursorCreatedAt", cursorCreatedAt);
+        params.put("cursorId", cursorId);
     }
 
-    private BooleanExpression eqReturnHomeTime(ChecklistFilterRequest request) {
-        return isBlank(request.returnHomeTime()) ? null : roomRule.returnHomeTime.eq(request.returnHomeTime());
+    private void appendOrderBy(StringBuilder sql, String alias, ChecklistFilterRequest.SortType sortType) {
+        if (sortType == ChecklistFilterRequest.SortType.REMAINING) {
+            sql.append(alias).append(".remaining ASC, ")
+                    .append(alias).append(".created_at DESC, ")
+                    .append(alias).append(".room_no DESC");
+            return;
+        }
+
+        sql.append(alias).append(".created_at DESC, ")
+                .append(alias).append(".room_no DESC");
     }
 
-    private BooleanExpression eqCleaning(ChecklistFilterRequest request) {
-        return request.cleaning() == null ? null : roomRule.cleaning.eq(request.cleaning());
+    private FindRoomsResponse toFindRoomsResponse(Object[] row) {
+        return new FindRoomsResponse(
+                stringValue(row[0]),
+                enumValue(RoomType.class, row[1]),
+                intValue(row[2]),
+                intValue(row[3]),
+                localDateTimeValue(row[4]),
+                stringValue(row[5]),
+                stringValue(row[6]),
+                enumValue(RoomStatus.class, row[7]),
+                stringValue(row[8]),
+                intValue(row[9])
+        );
     }
 
-    private BooleanExpression eqPhoneCall(ChecklistFilterRequest request) {
-        return request.phoneCall() == null ? null : roomRule.phoneCall.eq(request.phoneCall());
+    private <T extends Enum<T>> T enumValue(Class<T> enumType, Object value) {
+        return value == null ? null : Enum.valueOf(enumType, value.toString());
     }
 
-    private BooleanExpression eqSleepLight(ChecklistFilterRequest request) {
-        return request.sleepLight() == null ? null : roomRule.sleepLight.eq(request.sleepLight());
+    private String enumName(Enum<?> value) {
+        return value == null ? null : value.name();
     }
 
-    private BooleanExpression eqSleepHabit(ChecklistFilterRequest request) {
-        return request.sleepHabit() == null ? null : roomRule.sleepHabit.eq(request.sleepHabit());
+    private String stringValue(Object value) {
+        return value == null ? null : value.toString();
     }
 
-    private BooleanExpression eqSnoring(ChecklistFilterRequest request) {
-        return request.snoring() == null ? null : roomRule.snoring.eq(request.snoring());
+    private Integer intValue(Object value) {
+        return value == null ? null : ((Number) value).intValue();
     }
 
-    private BooleanExpression eqShowerTime(ChecklistFilterRequest request) {
-        return request.showerTime() == null ? null : roomRule.showerTime.eq(request.showerTime());
-    }
-
-    private BooleanExpression eqEating(ChecklistFilterRequest request) {
-        return request.eating() == null ? null : roomRule.eating.eq(request.eating());
-    }
-
-    private BooleanExpression eqLightsOut(ChecklistFilterRequest request) {
-        return request.lightsOut() == null ? null : roomRule.lightsOut.eq(request.lightsOut());
-    }
-
-    private BooleanExpression eqLightsOutTime(ChecklistFilterRequest request) {
-        return isBlank(request.lightsOutTime()) ? null : roomRule.lightsOutTime.eq(request.lightsOutTime());
-    }
-
-    private BooleanExpression eqHomeVisit(ChecklistFilterRequest request) {
-        return request.homeVisit() == null ? null : roomRule.homeVisit.eq(request.homeVisit());
-    }
-
-    private BooleanExpression eqSmoking(ChecklistFilterRequest request) {
-        return request.smoking() == null ? null : roomRule.smoking.eq(request.smoking());
-    }
-
-    private BooleanExpression eqRefrigerator(ChecklistFilterRequest request) {
-        return request.refrigerator() == null ? null : roomRule.refrigerator.eq(request.refrigerator());
-    }
-
-    private BooleanExpression eqHairDryer(ChecklistFilterRequest request) {
-        return isBlank(request.hairDryer()) ? null : roomRule.hairDryer.eq(request.hairDryer());
-    }
-
-    private BooleanExpression eqAlarm(ChecklistFilterRequest request) {
-        return request.alarm() == null ? null : roomRule.alarm.eq(request.alarm());
-    }
-
-    private BooleanExpression eqEarphone(ChecklistFilterRequest request) {
-        return request.earphone() == null ? null : roomRule.earphone.eq(request.earphone());
-    }
-
-    private BooleanExpression eqKeyskin(ChecklistFilterRequest request) {
-        return request.keyskin() == null ? null : roomRule.keyskin.eq(request.keyskin());
-    }
-
-    private BooleanExpression eqHeat(ChecklistFilterRequest request) {
-        return request.heat() == null ? null : roomRule.heat.eq(request.heat());
-    }
-
-    private BooleanExpression eqCold(ChecklistFilterRequest request) {
-        return request.cold() == null ? null : roomRule.cold.eq(request.cold());
-    }
-
-    private BooleanExpression eqStudy(ChecklistFilterRequest request) {
-        return request.study() == null ? null : roomRule.study.eq(request.study());
-    }
-
-    private BooleanExpression eqTrashCan(ChecklistFilterRequest request) {
-        return request.trashCan() == null ? null : roomRule.trashCan.eq(request.trashCan());
+    private LocalDateTime localDateTimeValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime;
+        }
+        if (value instanceof Timestamp timestamp) {
+            return timestamp.toLocalDateTime();
+        }
+        return LocalDateTime.parse(value.toString().replace(' ', 'T'));
     }
 
     private boolean isBlank(String value) {

--- a/src/main/java/com/project/dorumdorum/global/pagination/CursorCodec.java
+++ b/src/main/java/com/project/dorumdorum/global/pagination/CursorCodec.java
@@ -12,6 +12,12 @@ public final class CursorCodec {
                 .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
     }
 
+    public static String encode(int remaining, LocalDateTime createdAt, String id) {
+        String raw = remaining + "|" + createdAt + "|" + id;
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
     public static DecodedCursor decode(String cursor) {
         if (cursor == null || cursor.isBlank())
             return null;
@@ -24,8 +30,9 @@ public final class CursorCodec {
 
         LocalDateTime createdAt = LocalDateTime.parse(parts[parts.length - 2]);
         String id = parts[parts.length - 1];
+        Integer remaining = parts.length >= 3 ? Integer.parseInt(parts[0]) : null;
 
-        return new DecodedCursor(createdAt, id);
+        return new DecodedCursor(createdAt, id, remaining);
     }
 }
 

--- a/src/main/java/com/project/dorumdorum/global/pagination/CursorQueryParams.java
+++ b/src/main/java/com/project/dorumdorum/global/pagination/CursorQueryParams.java
@@ -5,5 +5,6 @@ import java.time.LocalDateTime;
 public record CursorQueryParams(
         LocalDateTime cursorCreatedAt,
         String cursorId,
+        Integer cursorRemaining,
         int limitPlusOne
 ) {}

--- a/src/main/java/com/project/dorumdorum/global/pagination/DecodedCursor.java
+++ b/src/main/java/com/project/dorumdorum/global/pagination/DecodedCursor.java
@@ -4,5 +4,6 @@ import java.time.LocalDateTime;
 
 public record DecodedCursor(
         LocalDateTime createdAt,
-        String pk
+        String pk,
+        Integer remaining
 ) {}

--- a/src/main/java/com/project/dorumdorum/global/pagination/PaginationHelper.java
+++ b/src/main/java/com/project/dorumdorum/global/pagination/PaginationHelper.java
@@ -14,10 +14,10 @@ public final class PaginationHelper {
     public static CursorQueryParams prepareCursorQuery(String cursor, int limit) {
         int limitPlusOne = limitPlusOne(limit);
         if (cursor == null || cursor.isBlank()) {
-            return new CursorQueryParams(null, null, limitPlusOne);
+            return new CursorQueryParams(null, null, null, limitPlusOne);
         }
         DecodedCursor decoded = CursorCodec.decode(cursor);
-        return new CursorQueryParams(decoded.createdAt(), decoded.pk(), limitPlusOne);
+        return new CursorQueryParams(decoded.createdAt(), decoded.pk(), decoded.remaining(), limitPlusOne);
     }
 
     public static <T> CursorPage<T> buildCursorPage(List<T> results, int limit, Function<T, String> nextCursorEncoder) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -16,6 +16,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_device_user_device
 CREATE UNIQUE INDEX IF NOT EXISTS uk_room_request_user_room_direction
     ON room_request (user_no, room_no, direction);
 
+DROP INDEX IF EXISTS idx_room_status_remaining_created;
+
+CREATE INDEX IF NOT EXISTS idx_room_status_remaining_created
+    ON room (room_status, remaining, created_at DESC, room_no DESC);
+
 ALTER TABLE IF EXISTS chat_room
     DROP CONSTRAINT IF EXISTS uk_chat_room_direct;
 

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/infra/repository/RoomRepositoryImplTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/infra/repository/RoomRepositoryImplTest.java
@@ -1,8 +1,8 @@
 package com.project.dorumdorum.domain.room.unit.infra.repository;
 
 import com.project.dorumdorum.domain.room.application.dto.request.ChecklistFilterRequest;
-import com.project.dorumdorum.domain.room.application.dto.request.RoomSort;
 import com.project.dorumdorum.domain.room.application.dto.response.FindRoomsResponse;
+import com.project.dorumdorum.domain.checklist.domain.entity.enums.SmokingType;
 import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
 import com.project.dorumdorum.domain.room.domain.entity.RoomStatus;
 import com.project.dorumdorum.domain.room.domain.entity.RoomType;
@@ -10,6 +10,8 @@ import com.project.dorumdorum.domain.room.infra.repository.RoomRepositoryImpl;
 import com.querydsl.core.types.Expression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,6 +33,7 @@ import static org.mockito.Mockito.*;
 class RoomRepositoryImplTest {
 
     @Mock private JPAQueryFactory queryFactory;
+    @Mock private EntityManager entityManager;
 
     private ChecklistFilterRequest request(ChecklistFilterRequest.SortType sortType) {
         return new ChecklistFilterRequest(
@@ -44,11 +48,11 @@ class RoomRepositoryImplTest {
     @Test
     @DisplayName("Should fetch room list for recruiting relation")
     void findByCursor_WhenRecruiting_FetchesWithLimit() {
-        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory);
+        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory, entityManager);
         JPAQuery<FindRoomsResponse> jpaQuery = mock(JPAQuery.class, RETURNS_SELF);
         List<FindRoomsResponse> expected = List.of(
                 new FindRoomsResponse("r1", RoomType.TYPE_1, 2, 1, LocalDateTime.now(),
-                        "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name())
+                        "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name(), 1)
         );
 
         when(queryFactory.select(org.mockito.ArgumentMatchers.<Expression<FindRoomsResponse>>any())).thenReturn(jpaQuery);
@@ -63,7 +67,7 @@ class RoomRepositoryImplTest {
         );
 
         List<FindRoomsResponse> result = repository.findByCursor(
-                request, cursorCreatedAt, "r1", 51
+                request, cursorCreatedAt, "r1", 1, 51
         );
 
         assertThat(result).isEqualTo(expected);
@@ -75,7 +79,7 @@ class RoomRepositoryImplTest {
     @Test
     @DisplayName("Should fetch room list with created-at sort cursor")
     void findByCursor_WithCreatedAtSortCursor_Fetches() {
-        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory);
+        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory, entityManager);
         JPAQuery<FindRoomsResponse> jpaQuery = mock(JPAQuery.class, RETURNS_SELF);
 
         when(queryFactory.select(org.mockito.ArgumentMatchers.<Expression<FindRoomsResponse>>any())).thenReturn(jpaQuery);
@@ -85,7 +89,7 @@ class RoomRepositoryImplTest {
         ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST);
 
         List<FindRoomsResponse> result = repository.findByCursor(
-                request, cursorCreatedAt, "r9", 11
+                request, cursorCreatedAt, "r9", null, 11
         );
 
         assertThat(result).isEmpty();
@@ -96,7 +100,7 @@ class RoomRepositoryImplTest {
     @Test
     @DisplayName("Should fetch room list with null cursor and empty filters")
     void findByCursor_WithNullCursorAndEmptyFilters_Fetches() {
-        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory);
+        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory, entityManager);
         JPAQuery<FindRoomsResponse> jpaQuery = mock(JPAQuery.class, RETURNS_SELF);
 
         when(queryFactory.select(org.mockito.ArgumentMatchers.<Expression<FindRoomsResponse>>any())).thenReturn(jpaQuery);
@@ -104,7 +108,7 @@ class RoomRepositoryImplTest {
         ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST);
 
         List<FindRoomsResponse> result = repository.findByCursor(
-                request, null, null, 7
+                request, null, null, null, 7
         );
 
         assertThat(result).isEmpty();
@@ -116,7 +120,7 @@ class RoomRepositoryImplTest {
     @Test
     @DisplayName("Should fetch room list with null sort using default branch")
     void findByCursor_WithNullSort_UsesDefaultOrderBranch() {
-        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory);
+        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory, entityManager);
         JPAQuery<FindRoomsResponse> jpaQuery = mock(JPAQuery.class, RETURNS_SELF);
 
         when(queryFactory.select(org.mockito.ArgumentMatchers.<Expression<FindRoomsResponse>>any())).thenReturn(jpaQuery);
@@ -126,21 +130,89 @@ class RoomRepositoryImplTest {
         ChecklistFilterRequest request = request(null);
 
         List<FindRoomsResponse> result = repository.findByCursor(
-                request, cursorCreatedAt, "r3", 5
+                request, cursorCreatedAt, "r3", null, 5
         );
 
         assertThat(result).isEmpty();
         verify(jpaQuery).limit(5L);
     }
 
+    @Test
+    @DisplayName("Should use native lateral query when checklist filters exist")
+    void findByCursor_WithChecklistFilters_UsesNativeLateralQuery() {
+        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory, entityManager);
+        Query nativeQuery = mock(Query.class);
+        LocalDateTime createdAt = LocalDateTime.now();
+        ChecklistFilterRequest request = new ChecklistFilterRequest(
+                ChecklistFilterRequest.SortType.REMAINING,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                SmokingType.NON_SMOKER,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        Object[] row = {
+                "r1",
+                RoomType.TYPE_1.name(),
+                2,
+                1,
+                createdAt,
+                "title",
+                "host",
+                RoomStatus.CONFIRM_PENDING.name(),
+                ResidencePeriod.SEMESTER.name(),
+                1
+        };
+
+        when(entityManager.createNativeQuery(anyString())).thenReturn(nativeQuery);
+        when(nativeQuery.setParameter(anyString(), any())).thenReturn(nativeQuery);
+        List<Object[]> rows = new ArrayList<>();
+        rows.add(row);
+        when(nativeQuery.getResultList()).thenReturn(rows);
+
+        List<FindRoomsResponse> result = repository.findByCursor(request, createdAt, "r1", 1, 51);
+
+        assertThat(result).containsExactly(
+                new FindRoomsResponse("r1", RoomType.TYPE_1, 2, 1, createdAt,
+                        "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name(), 1)
+        );
+        verify(entityManager).createNativeQuery(anyString());
+        verify(nativeQuery).getResultList();
+        verifyNoInteractions(queryFactory);
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     @DisplayName("Should return optional result for my room query")
     void findMyRoom_ReturnsOptional() {
-        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory);
+        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory, entityManager);
         JPAQuery<FindRoomsResponse> jpaQuery = mock(JPAQuery.class, RETURNS_SELF);
         FindRoomsResponse response = new FindRoomsResponse("r1", RoomType.TYPE_1, 2, 1, LocalDateTime.now(),
-                "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name());
+                "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name(), 1);
 
         when(queryFactory.select(org.mockito.ArgumentMatchers.<Expression<FindRoomsResponse>>any())).thenReturn(jpaQuery);
         when(jpaQuery.fetchOne()).thenReturn(response);
@@ -155,7 +227,7 @@ class RoomRepositoryImplTest {
     @Test
     @DisplayName("Should return empty optional when my room does not exist")
     void findMyRoom_WhenMissing_ReturnsEmpty() {
-        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory);
+        RoomRepositoryImpl repository = new RoomRepositoryImpl(queryFactory, entityManager);
         JPAQuery<FindRoomsResponse> jpaQuery = mock(JPAQuery.class, RETURNS_SELF);
         when(queryFactory.select(org.mockito.ArgumentMatchers.<Expression<FindRoomsResponse>>any())).thenReturn(jpaQuery);
         when(jpaQuery.fetchOne()).thenReturn(null);

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/service/RoomServiceTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/service/RoomServiceTest.java
@@ -60,7 +60,7 @@ class RoomServiceTest {
     void searchByCursor_DelegatesToRepository() {
         List<FindRoomsResponse> expected = List.of(
                 new FindRoomsResponse("r1", RoomType.TYPE_1, 2, 1, LocalDateTime.now(),
-                        "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name())
+                        "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name(), 1)
         );
         ChecklistFilterRequest request = new ChecklistFilterRequest(
                 ChecklistFilterRequest.SortType.LATEST, null, null, null, null,
@@ -68,11 +68,11 @@ class RoomServiceTest {
                 null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null
         );
-        when(roomRepository.findByCursor(any(), any(), any(), anyInt()))
+        when(roomRepository.findByCursor(any(), any(), any(), any(), anyInt()))
                 .thenReturn(expected);
 
         List<FindRoomsResponse> result = service.searchByCursor(
-                request, null, null, 10
+                request, null, null, null, 10
         );
 
         assertThat(result).isEqualTo(expected);

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/FindRoomsUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/FindRoomsUseCaseTest.java
@@ -34,7 +34,7 @@ class FindRoomsUseCaseTest {
 
     private FindRoomsResponse room(String roomNo, int capacity, int current, LocalDateTime createdAt) {
         return new FindRoomsResponse(roomNo, RoomType.TYPE_1, capacity, current, createdAt, "title",
-                "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name());
+                "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name(), capacity - current);
     }
 
     private ChecklistFilterRequest request(ChecklistFilterRequest.SortType sortType, String cursor) {
@@ -54,7 +54,7 @@ class FindRoomsUseCaseTest {
                 .mapToObj(i -> room("r" + i, 2, 1, now.minusMinutes(i)))
                 .toList();
         ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST, null);
-        when(roomService.searchByCursor(any(), any(), any(), anyInt()))
+        when(roomService.searchByCursor(any(), any(), any(), any(), anyInt()))
                 .thenReturn(responses);
 
         CursorPage<FindRoomsResponse> result = useCase.execute(request);
@@ -62,7 +62,7 @@ class FindRoomsUseCaseTest {
         assertThat(result.items()).hasSize(50);
         assertThat(result.hasNext()).isTrue();
         assertThat(result.nextCursor()).isNotBlank();
-        verify(roomService).searchByCursor(any(), any(), any(), anyInt());
+        verify(roomService).searchByCursor(any(), any(), any(), any(), anyInt());
     }
 
     @Test
@@ -70,7 +70,7 @@ class FindRoomsUseCaseTest {
     void execute_WhenResponsesWithinLimit_ReturnsHasNextFalse() {
         List<FindRoomsResponse> responses = List.of(room("r1", 2, 1, LocalDateTime.now()));
         ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.REMAINING, null);
-        when(roomService.searchByCursor(any(), any(), any(), anyInt()))
+        when(roomService.searchByCursor(any(), any(), any(), any(), anyInt()))
                 .thenReturn(responses);
 
         CursorPage<FindRoomsResponse> result = useCase.execute(request);
@@ -84,7 +84,7 @@ class FindRoomsUseCaseTest {
     @DisplayName("Should return null nextCursor when no response")
     void execute_WhenNoResponse_ReturnsNullCursor() {
         ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST, null);
-        when(roomService.searchByCursor(any(), any(), any(), anyInt()))
+        when(roomService.searchByCursor(any(), any(), any(), any(), anyInt()))
                 .thenReturn(List.of());
 
         CursorPage<FindRoomsResponse> result = useCase.execute(request);
@@ -100,12 +100,12 @@ class FindRoomsUseCaseTest {
         List<FindRoomsResponse> responses = List.of(room("r1", 2, 1, LocalDateTime.now()));
         String cursor = com.project.dorumdorum.global.pagination.CursorCodec.encode(LocalDateTime.now(), "r1");
         ChecklistFilterRequest request = request(ChecklistFilterRequest.SortType.LATEST, cursor);
-        when(roomService.searchByCursor(any(), any(), any(), anyInt()))
+        when(roomService.searchByCursor(any(), any(), any(), any(), anyInt()))
                 .thenReturn(responses);
 
         CursorPage<FindRoomsResponse> result = useCase.execute(request);
 
         assertThat(result.items()).hasSize(1);
-        verify(roomService).searchByCursor(any(), any(), any(), anyInt());
+        verify(roomService).searchByCursor(any(), any(), any(), any(), anyInt());
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/LoadMyRoomsUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/LoadMyRoomsUseCaseTest.java
@@ -30,7 +30,7 @@ class LoadMyRoomsUseCaseTest {
     @DisplayName("Should return my room from room service")
     void execute_ReturnsMyRoom() {
         FindRoomsResponse expected = new FindRoomsResponse("r1", RoomType.TYPE_1, 2, 1, LocalDateTime.now(),
-                "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name());
+                "title", "host", RoomStatus.CONFIRM_PENDING, ResidencePeriod.SEMESTER.name(), 1);
         when(roomService.findMyRoom("u1")).thenReturn(expected);
 
         FindRoomsResponse result = useCase.execute("u1");


### PR DESCRIPTION
# 📝 Pull Request Template

## 📌 제목
> [FEAT] 체크리스트 기반 방 필터링 조회 쿼리 최적화

---
## 📢 요약
> 체크리스트 조건이 포함된 방 조회에서 `room_rule` 중심으로 실행 계획이 잡히며 `ORDER BY + LIMIT`가 늦게 적용되는 문제를 개선했습니다.  
> 체크리스트 검색 경로를 별도로 최적화해 방 테이블 주도의 조회 흐름을 유도하고, `remaining` 정렬에서는 커서와 정렬 기준, 인덱스 방향을 함께 맞춰 정렬/페이징 정합성을 보완했습니다.  
> 이와 함께 응답 DTO, 커서 처리 로직, 테스트 코드를 전반적으로 수정해 변경된 조회 전략이 서비스 레이어와 테스트에 일관되게 반영되도록 정리했습니다.

🔗 **연관 이슈**: Resolves #이슈번호

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 CSS/UI 디자인 변경
- [ ] 🔧 코드에 영향 없는 변경(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 🔨 코드 리팩토링
- [ ] 📝 주석 추가 및 수정
- [ ] 📄 문서 수정
- [x] 🧪 테스트 추가 또는 리팩토링
- [ ] 🏗️ 빌드 및 패키지 매니저 수정
- [ ] 📂 파일 또는 폴더명 수정
- [ ] 🗑️ 파일 또는 폴더 삭제

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 기타
> **리뷰어가 알면 좋을 추가 사항을 적어주세요.**

### 변경 배경
- 기존 체크리스트 기반 방 조회는 `room`과 `room_rule`를 직접 결합한 구조로 동작해, 일부 정렬 시나리오에서 PostgreSQL이 비효율적인 실행 계획을 선택할 여지가 있었습니다.
- 특히 `remaining` 정렬에서는 체크리스트 조건과 정렬 조건이 함께 적용되며 `Sort`와 늦은 `LIMIT` 적용이 발생할 수 있어, 최악 구간의 성능 저하 가능성이 있었습니다.

### 주요 변경 사항
- 체크리스트 조건이 없는 조회는 기존 QueryDSL 경로를 유지했습니다.
- 체크리스트 조건이 포함된 조회는 별도 최적화 경로로 분리했습니다.
- 체크리스트 조회 경로는 `JOIN LATERAL` 기반 구조로 재구성해 방 테이블을 먼저 탐색하고 각 방마다 체크리스트 일치 여부를 확인하도록 변경했습니다.
- `remaining` 정렬은 커서 기준을 함께 조정해 정렬 순서와 페이징 기준이 일치하도록 맞췄습니다.
- 응답 DTO에 `remaining` 값을 포함하도록 변경해 커서 생성과 다음 페이지 판단이 정렬 기준과 일관되게 동작하도록 수정했습니다.
- 정렬 기준에 맞춰 스키마 인덱스 정의도 함께 조정했습니다.

### 테스트 및 검증
- 변경된 조회 경로에 맞춰 repository / service / usecase 테스트를 함께 수정했습니다.
- 체크리스트 포함 여부, `remaining` 정렬 커서 처리, 응답 생성 흐름이 기존과 다르게 깨지지 않도록 검증했습니다.

### 참고
- 이번 변경은 체크리스트 기반 조회 경로의 실행 계획 안정화와 정렬/커서 정합성 확보에 초점을 맞췄습니다.
- 체크리스트가 없는 일반 조회 경로는 기존 구조를 유지해 영향 범위를 최소화했습니다.