### PR TITLE
[FIX] 방 관리 기능 개선 및 버그 수정 (+ 채팅 refactor)

### DIFF
--- a/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/NotificationMessage.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/NotificationMessage.java
@@ -1,0 +1,15 @@
+package com.project.dorumdorum.domain.chat.application.dto.response;
+
+public record NotificationMessage(
+        String type,
+        String roomNo,
+        String chatRoomNo
+) {
+    public static NotificationMessage roomDeleted(String roomNo, String chatRoomNo) {
+        return new NotificationMessage("ROOM_DELETED", roomNo, chatRoomNo);
+    }
+
+    public static NotificationMessage kicked(String roomNo, String chatRoomNo) {
+        return new NotificationMessage("KICKED_FROM_ROOM", roomNo, chatRoomNo);
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/NotificationMessage.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/NotificationMessage.java
@@ -1,15 +1,15 @@
 package com.project.dorumdorum.domain.chat.application.dto.response;
 
 public record NotificationMessage(
-        String type,
+        NotificationType type,
         String roomNo,
         String chatRoomNo
 ) {
     public static NotificationMessage roomDeleted(String roomNo, String chatRoomNo) {
-        return new NotificationMessage("ROOM_DELETED", roomNo, chatRoomNo);
+        return new NotificationMessage(NotificationType.ROOM_DELETED, roomNo, chatRoomNo);
     }
 
     public static NotificationMessage kicked(String roomNo, String chatRoomNo) {
-        return new NotificationMessage("KICKED_FROM_ROOM", roomNo, chatRoomNo);
+        return new NotificationMessage(NotificationType.KICKED_FROM_ROOM, roomNo, chatRoomNo);
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/NotificationType.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/dto/response/NotificationType.java
@@ -1,0 +1,19 @@
+package com.project.dorumdorum.domain.chat.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum NotificationType {
+    ROOM_DELETED("ROOM_DELETED"),
+    KICKED_FROM_ROOM("KICKED_FROM_ROOM");
+
+    private final String value;
+
+    NotificationType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/ChatWebSocketNotificationEvent.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/ChatWebSocketNotificationEvent.java
@@ -1,0 +1,12 @@
+package com.project.dorumdorum.domain.chat.application.event;
+
+import java.util.List;
+
+public record ChatWebSocketNotificationEvent(
+        List<BroadcastTask> broadcasts,
+        List<UserNotifyTask> userNotifications
+) {
+    public record BroadcastTask(String chatRoomNo, Object payload) {}
+
+    public record UserNotifyTask(String userNo, Object payload) {}
+}

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/ChatWebSocketNotificationEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/ChatWebSocketNotificationEventListener.java
@@ -1,0 +1,24 @@
+package com.project.dorumdorum.domain.chat.application.event;
+
+import com.project.dorumdorum.domain.chat.infra.websocket.ChatWebSocketSendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ChatWebSocketNotificationEventListener {
+
+    private final ChatWebSocketSendService chatWebSocketSendService;
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = false)
+    public void handle(ChatWebSocketNotificationEvent event) {
+        event.broadcasts().forEach(task ->
+                chatWebSocketSendService.broadcast(task.chatRoomNo(), task.payload()));
+        event.userNotifications().forEach(task ->
+                chatWebSocketSendService.notifyUser(task.userNo(), task.payload()));
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/ChatWebSocketNotificationEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/ChatWebSocketNotificationEventListener.java
@@ -16,9 +16,9 @@ public class ChatWebSocketNotificationEventListener {
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = false)
     public void handle(ChatWebSocketNotificationEvent event) {
-        event.broadcasts().forEach(task ->
-                chatWebSocketSendService.broadcast(task.chatRoomNo(), task.payload()));
         event.userNotifications().forEach(task ->
                 chatWebSocketSendService.notifyUser(task.userNo(), task.payload()));
+        event.broadcasts().forEach(task ->
+                chatWebSocketSendService.broadcast(task.chatRoomNo(), task.payload()));
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoomDeletedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoomDeletedEventListener.java
@@ -55,7 +55,7 @@ public class RoomDeletedEventListener {
 
         chatMessageService.deleteAllByChatRoom(chatRoom.getChatRoomNo());
         chatRoomMemberService.deleteAllByChatRoom(chatRoom);
-        chatRoomService.delete(chatRoom);
+        chatRoomService.deleteByChatRoomNo(chatRoom.getChatRoomNo());
     }
 
     private void broadcastDeletionSafely(ChatRoom chatRoom, NotificationMessage notification) {

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoomDeletedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoomDeletedEventListener.java
@@ -8,15 +8,14 @@ import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
 import com.project.dorumdorum.domain.chat.domain.service.ChatRoomService;
 import com.project.dorumdorum.domain.room.application.event.RoomDeletedEvent;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.ArrayList;
 import java.util.List;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RoomDeletedEventListener {
@@ -24,53 +23,40 @@ public class RoomDeletedEventListener {
     private final ChatRoomService chatRoomService;
     private final ChatRoomMemberService chatRoomMemberService;
     private final ChatMessageService chatMessageService;
-    private final SimpMessagingTemplate messagingTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 방 삭제(RoomDeletedEvent) → GROUP·DIRECT 채팅방 전체 삭제 처리
      * 발행: DeleteRoomUseCase (room 도메인 담당자)
      *
      * BEFORE_COMMIT: 부모 트랜잭션(DeleteRoomUseCase)에 참여하여 방 삭제 + 채팅방 삭제를 하나의 트랜잭션으로 처리.
-     * WebSocket 브로드캐스트는 트랜잭션 외부 작업이므로 실패가 TX에 영향을 주지 않도록 독립 처리.
+     * WebSocket 알림 페이로드를 수집한 뒤 ChatWebSocketNotificationEvent로 발행 →
+     * AFTER_COMMIT에서 비동기 재처리(exponential backoff)로 전송.
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handle(RoomDeletedEvent event) {
         List<ChatRoom> chatRooms = chatRoomService.findAllByRoomNo(event.roomNo());
+
+        List<ChatWebSocketNotificationEvent.BroadcastTask> broadcasts = new ArrayList<>();
+        List<ChatWebSocketNotificationEvent.UserNotifyTask> userNotifications = new ArrayList<>();
+
         for (ChatRoom chatRoom : chatRooms) {
-            notifyAndClean(chatRoom, event.roomNo());
-        }
-    }
+            NotificationMessage notification = NotificationMessage.roomDeleted(event.roomNo(), chatRoom.getChatRoomNo());
+            broadcasts.add(new ChatWebSocketNotificationEvent.BroadcastTask(chatRoom.getChatRoomNo(), notification));
 
-    private void notifyAndClean(ChatRoom chatRoom, String roomNo) {
-        NotificationMessage notification = NotificationMessage.roomDeleted(roomNo, chatRoom.getChatRoomNo());
+            if (ChatRoomType.DIRECT.equals(chatRoom.getChatRoomType())
+                    && chatRoom.getApplicantUserNo() != null) {
+                userNotifications.add(new ChatWebSocketNotificationEvent.UserNotifyTask(
+                        chatRoom.getApplicantUserNo(), notification));
+            }
 
-        // 채팅방 열려 있는 유저에게 브로드캐스트 (/topic/)
-        broadcastDeletionSafely(chatRoom, notification);
-
-        // DIRECT 채팅방은 지원자가 다른 화면에 있어도 받을 수 있도록 개인 큐로 추가 전송 (/queue/)
-        if (ChatRoomType.DIRECT.equals(chatRoom.getChatRoomType())
-                && chatRoom.getApplicantUserNo() != null) {
-            notifyUserSafely(chatRoom.getApplicantUserNo(), notification);
+            chatMessageService.deleteAllByChatRoom(chatRoom.getChatRoomNo());
+            chatRoomMemberService.deleteAllByChatRoom(chatRoom);
+            chatRoomService.deleteByChatRoomNo(chatRoom.getChatRoomNo());
         }
 
-        chatMessageService.deleteAllByChatRoom(chatRoom.getChatRoomNo());
-        chatRoomMemberService.deleteAllByChatRoom(chatRoom);
-        chatRoomService.deleteByChatRoomNo(chatRoom.getChatRoomNo());
-    }
-
-    private void broadcastDeletionSafely(ChatRoom chatRoom, NotificationMessage notification) {
-        try {
-            messagingTemplate.convertAndSend("/topic/chat-room/" + chatRoom.getChatRoomNo(), notification);
-        } catch (Exception e) {
-            log.warn("[Chat] 방 삭제 WebSocket 브로드캐스트 실패. chatRoomNo={}", chatRoom.getChatRoomNo(), e);
-        }
-    }
-
-    private void notifyUserSafely(String userNo, NotificationMessage notification) {
-        try {
-            messagingTemplate.convertAndSendToUser(userNo, "/queue/notification", notification);
-        } catch (Exception e) {
-            log.warn("[Chat] 개인 알림 전송 실패. userNo={}", userNo, e);
+        if (!broadcasts.isEmpty() || !userNotifications.isEmpty()) {
+            eventPublisher.publishEvent(new ChatWebSocketNotificationEvent(broadcasts, userNotifications));
         }
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoomDeletedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoomDeletedEventListener.java
@@ -1,0 +1,76 @@
+package com.project.dorumdorum.domain.chat.application.event;
+
+import com.project.dorumdorum.domain.chat.application.dto.response.NotificationMessage;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomType;
+import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
+import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
+import com.project.dorumdorum.domain.chat.domain.service.ChatRoomService;
+import com.project.dorumdorum.domain.room.application.event.RoomDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomDeletedEventListener {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatRoomMemberService chatRoomMemberService;
+    private final ChatMessageService chatMessageService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * 방 삭제(RoomDeletedEvent) → GROUP·DIRECT 채팅방 전체 삭제 처리
+     * 발행: DeleteRoomUseCase (room 도메인 담당자)
+     *
+     * BEFORE_COMMIT: 부모 트랜잭션(DeleteRoomUseCase)에 참여하여 방 삭제 + 채팅방 삭제를 하나의 트랜잭션으로 처리.
+     * WebSocket 브로드캐스트는 트랜잭션 외부 작업이므로 실패가 TX에 영향을 주지 않도록 독립 처리.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handle(RoomDeletedEvent event) {
+        List<ChatRoom> chatRooms = chatRoomService.findAllByRoomNo(event.roomNo());
+        for (ChatRoom chatRoom : chatRooms) {
+            notifyAndClean(chatRoom, event.roomNo());
+        }
+    }
+
+    private void notifyAndClean(ChatRoom chatRoom, String roomNo) {
+        NotificationMessage notification = NotificationMessage.roomDeleted(roomNo, chatRoom.getChatRoomNo());
+
+        // 채팅방 열려 있는 유저에게 브로드캐스트 (/topic/)
+        broadcastDeletionSafely(chatRoom, notification);
+
+        // DIRECT 채팅방은 지원자가 다른 화면에 있어도 받을 수 있도록 개인 큐로 추가 전송 (/queue/)
+        if (ChatRoomType.DIRECT.equals(chatRoom.getChatRoomType())
+                && chatRoom.getApplicantUserNo() != null) {
+            notifyUserSafely(chatRoom.getApplicantUserNo(), notification);
+        }
+
+        chatMessageService.deleteAllByChatRoom(chatRoom.getChatRoomNo());
+        chatRoomMemberService.deleteAllByChatRoom(chatRoom);
+        chatRoomService.delete(chatRoom);
+    }
+
+    private void broadcastDeletionSafely(ChatRoom chatRoom, NotificationMessage notification) {
+        try {
+            messagingTemplate.convertAndSend("/topic/chat-room/" + chatRoom.getChatRoomNo(), notification);
+        } catch (Exception e) {
+            log.warn("[Chat] 방 삭제 WebSocket 브로드캐스트 실패. chatRoomNo={}", chatRoom.getChatRoomNo(), e);
+        }
+    }
+
+    private void notifyUserSafely(String userNo, NotificationMessage notification) {
+        try {
+            messagingTemplate.convertAndSendToUser(userNo, "/queue/notification", notification);
+        } catch (Exception e) {
+            log.warn("[Chat] 개인 알림 전송 실패. userNo={}", userNo, e);
+        }
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoomDeletedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoomDeletedEventListener.java
@@ -2,7 +2,7 @@ package com.project.dorumdorum.domain.chat.application.event;
 
 import com.project.dorumdorum.domain.chat.application.dto.response.NotificationMessage;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
-import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomType;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
 import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
 import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
 import com.project.dorumdorum.domain.chat.domain.service.ChatRoomService;
@@ -30,24 +30,22 @@ public class RoomDeletedEventListener {
      * 발행: DeleteRoomUseCase (room 도메인 담당자)
      *
      * BEFORE_COMMIT: 부모 트랜잭션(DeleteRoomUseCase)에 참여하여 방 삭제 + 채팅방 삭제를 하나의 트랜잭션으로 처리.
-     * WebSocket 알림 페이로드를 수집한 뒤 ChatWebSocketNotificationEvent로 발행 →
-     * AFTER_COMMIT에서 비동기 재처리(exponential backoff)로 전송.
+     * 채팅방 멤버 전원에게 /queue/notification으로 NotificationMessage 전달.
+     * /topic/chat-room/{chatRoomNo}는 ChatMessageResponse 전용 채널이므로 여기서 사용하지 않음.
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handle(RoomDeletedEvent event) {
         List<ChatRoom> chatRooms = chatRoomService.findAllByRoomNo(event.roomNo());
-
-        List<ChatWebSocketNotificationEvent.BroadcastTask> broadcasts = new ArrayList<>();
         List<ChatWebSocketNotificationEvent.UserNotifyTask> userNotifications = new ArrayList<>();
 
         for (ChatRoom chatRoom : chatRooms) {
             NotificationMessage notification = NotificationMessage.roomDeleted(event.roomNo(), chatRoom.getChatRoomNo());
-            broadcasts.add(new ChatWebSocketNotificationEvent.BroadcastTask(chatRoom.getChatRoomNo(), notification));
 
-            if (ChatRoomType.DIRECT.equals(chatRoom.getChatRoomType())
-                    && chatRoom.getApplicantUserNo() != null) {
+            // 삭제 전 멤버 조회 → 전원에게 /queue/notification 개인 알림
+            List<ChatRoomMember> members = chatRoomMemberService.findByChatRoom(chatRoom);
+            for (ChatRoomMember member : members) {
                 userNotifications.add(new ChatWebSocketNotificationEvent.UserNotifyTask(
-                        chatRoom.getApplicantUserNo(), notification));
+                        member.getUserNo(), notification));
             }
 
             chatMessageService.deleteAllByChatRoom(chatRoom.getChatRoomNo());
@@ -55,8 +53,8 @@ public class RoomDeletedEventListener {
             chatRoomService.deleteByChatRoomNo(chatRoom.getChatRoomNo());
         }
 
-        if (!broadcasts.isEmpty() || !userNotifications.isEmpty()) {
-            eventPublisher.publishEvent(new ChatWebSocketNotificationEvent(broadcasts, userNotifications));
+        if (!userNotifications.isEmpty()) {
+            eventPublisher.publishEvent(new ChatWebSocketNotificationEvent(List.of(), userNotifications));
         }
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
@@ -1,6 +1,7 @@
 package com.project.dorumdorum.domain.chat.application.event;
 
 import com.project.dorumdorum.domain.chat.application.dto.response.ChatMessageResponse;
+import com.project.dorumdorum.domain.chat.application.dto.response.NotificationMessage;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatMessage;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
@@ -58,6 +59,8 @@ public class RoommateKickedEventListener {
                         message.getMessageNo(), chatRoom.getChatRoomNo(),
                         "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt(), message.getUnreadCount());
                 broadcastSafely(chatRoom, response);
+                notifyUserSafely(event.kickedUserNo(),
+                        NotificationMessage.kicked(event.roomNo(), chatRoom.getChatRoomNo()));
             }
         });
     }
@@ -67,6 +70,14 @@ public class RoommateKickedEventListener {
             messagingTemplate.convertAndSend("/topic/chat-room/" + chatRoom.getChatRoomNo(), response);
         } catch (Exception e) {
             log.warn("[Chat] WebSocket 브로드캐스트 실패. chatRoomNo={}", chatRoom.getChatRoomNo(), e);
+        }
+    }
+
+    private void notifyUserSafely(String userNo, NotificationMessage notification) {
+        try {
+            messagingTemplate.convertAndSendToUser(userNo, "/queue/notification", notification);
+        } catch (Exception e) {
+            log.warn("[Chat] 개인 알림 전송 실패. userNo={}", userNo, e);
         }
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
@@ -42,27 +42,29 @@ public class RoommateKickedEventListener {
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handle(RoommateKickedEvent event) {
-        chatRoomService.findByRoomNo(event.roomNo()).ifPresent(chatRoom -> {
-            if (chatRoomMemberService.isMember(chatRoom, event.kickedUserNo())) {
-                ChatRoomMember member = chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, event.kickedUserNo());
-                LocalDateTime fromTime = member.getLastReadAt() != null
-                        ? member.getLastReadAt()
-                        : member.getJoinedAt();
-                chatMessageService.decreaseUnreadCount(chatRoom.getChatRoomNo(), fromTime, event.kickedUserNo());
-                chatRoomMemberService.leave(member);
-                User kicked = userService.findById(event.kickedUserNo());
-                String displayName = (kicked.getNickname() != null && !kicked.getNickname().isBlank())
-                        ? kicked.getNickname() : kicked.getName();
-                String content = displayName + "가 퇴장했습니다.";
-                ChatMessage message = chatMessageService.save(chatRoom, "SYSTEM", content, MessageType.SYSTEM, 0);
-                ChatMessageResponse response = new ChatMessageResponse(
-                        message.getMessageNo(), chatRoom.getChatRoomNo(),
-                        "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt(), message.getUnreadCount());
-                broadcastSafely(chatRoom, response);
-                notifyUserSafely(event.kickedUserNo(),
-                        NotificationMessage.kicked(event.roomNo(), chatRoom.getChatRoomNo()));
-            }
-        });
+        chatRoomService.findByRoomNo(event.roomNo()).ifPresent(chatRoom ->
+                chatRoomMemberService.findOptionalByChatRoomAndUserNo(chatRoom, event.kickedUserNo())
+                        .ifPresent(member -> processKick(chatRoom, member, event))
+        );
+    }
+
+    private void processKick(ChatRoom chatRoom, ChatRoomMember member, RoommateKickedEvent event) {
+        LocalDateTime fromTime = member.getLastReadAt() != null
+                ? member.getLastReadAt()
+                : member.getJoinedAt();
+        chatMessageService.decreaseUnreadCount(chatRoom.getChatRoomNo(), fromTime, event.kickedUserNo());
+        chatRoomMemberService.leave(member);
+        User kicked = userService.findById(event.kickedUserNo());
+        String displayName = (kicked.getNickname() != null && !kicked.getNickname().isBlank())
+                ? kicked.getNickname() : kicked.getName();
+        String content = displayName + "가 퇴장했습니다.";
+        ChatMessage message = chatMessageService.save(chatRoom, "SYSTEM", content, MessageType.SYSTEM, 0);
+        ChatMessageResponse response = new ChatMessageResponse(
+                message.getMessageNo(), chatRoom.getChatRoomNo(),
+                "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt(), message.getUnreadCount());
+        broadcastSafely(chatRoom, response);
+        notifyUserSafely(event.kickedUserNo(),
+                NotificationMessage.kicked(event.roomNo(), chatRoom.getChatRoomNo()));
     }
 
     private void broadcastSafely(ChatRoom chatRoom, ChatMessageResponse response) {

--- a/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/application/event/RoommateKickedEventListener.java
@@ -13,15 +13,14 @@ import com.project.dorumdorum.domain.room.application.event.RoommateKickedEvent;
 import com.project.dorumdorum.domain.user.domain.entity.User;
 import com.project.dorumdorum.domain.user.domain.service.UserService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RoommateKickedEventListener {
@@ -30,7 +29,7 @@ public class RoommateKickedEventListener {
     private final ChatRoomMemberService chatRoomMemberService;
     private final ChatMessageService chatMessageService;
     private final UserService userService;
-    private final SimpMessagingTemplate messagingTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 룸메이트 강퇴(RoommateKickedEvent) → 채팅방에서 퇴장 처리
@@ -38,7 +37,8 @@ public class RoommateKickedEventListener {
      *
      * BEFORE_COMMIT: 부모 트랜잭션(KickRoommateUseCase)에 참여하여 방 강퇴 + 채팅방 퇴장을 하나의 트랜잭션으로 처리.
      * 채팅방 퇴장 실패 시 방 강퇴도 롤백되어 데이터 정합성 보장.
-     * WebSocket 브로드캐스트는 트랜잭션 외부 작업이므로 실패가 TX에 영향을 주지 않도록 독립 처리.
+     * WebSocket 알림 페이로드를 수집한 뒤 ChatWebSocketNotificationEvent로 발행 →
+     * AFTER_COMMIT에서 비동기 재처리(exponential backoff)로 전송.
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handle(RoommateKickedEvent event) {
@@ -54,32 +54,21 @@ public class RoommateKickedEventListener {
                 : member.getJoinedAt();
         chatMessageService.decreaseUnreadCount(chatRoom.getChatRoomNo(), fromTime, event.kickedUserNo());
         chatRoomMemberService.leave(member);
+
         User kicked = userService.findById(event.kickedUserNo());
         String displayName = (kicked.getNickname() != null && !kicked.getNickname().isBlank())
                 ? kicked.getNickname() : kicked.getName();
-        String content = displayName + "가 퇴장했습니다.";
+        String content = displayName + "님이 퇴장했습니다.";
         ChatMessage message = chatMessageService.save(chatRoom, "SYSTEM", content, MessageType.SYSTEM, 0);
-        ChatMessageResponse response = new ChatMessageResponse(
+
+        ChatMessageResponse broadcastPayload = new ChatMessageResponse(
                 message.getMessageNo(), chatRoom.getChatRoomNo(),
                 "SYSTEM", null, content, MessageType.SYSTEM.name(), message.getCreatedAt(), message.getUnreadCount());
-        broadcastSafely(chatRoom, response);
-        notifyUserSafely(event.kickedUserNo(),
-                NotificationMessage.kicked(event.roomNo(), chatRoom.getChatRoomNo()));
-    }
+        NotificationMessage notificationPayload = NotificationMessage.kicked(event.roomNo(), chatRoom.getChatRoomNo());
 
-    private void broadcastSafely(ChatRoom chatRoom, ChatMessageResponse response) {
-        try {
-            messagingTemplate.convertAndSend("/topic/chat-room/" + chatRoom.getChatRoomNo(), response);
-        } catch (Exception e) {
-            log.warn("[Chat] WebSocket 브로드캐스트 실패. chatRoomNo={}", chatRoom.getChatRoomNo(), e);
-        }
-    }
-
-    private void notifyUserSafely(String userNo, NotificationMessage notification) {
-        try {
-            messagingTemplate.convertAndSendToUser(userNo, "/queue/notification", notification);
-        } catch (Exception e) {
-            log.warn("[Chat] 개인 알림 전송 실패. userNo={}", userNo, e);
-        }
+        eventPublisher.publishEvent(new ChatWebSocketNotificationEvent(
+                List.of(new ChatWebSocketNotificationEvent.BroadcastTask(chatRoom.getChatRoomNo(), broadcastPayload)),
+                List.of(new ChatWebSocketNotificationEvent.UserNotifyTask(event.kickedUserNo(), notificationPayload))
+        ));
     }
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoom.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoom.java
@@ -16,7 +16,8 @@ import java.time.LocalDateTime;
 @Entity
 @Table(
         indexes = {
-                @Index(name = "idx_chat_room_last_message_at", columnList = "last_message_at")
+                @Index(name = "idx_chat_room_last_message_at", columnList = "last_message_at"),
+                @Index(name = "idx_chat_room_room_no", columnList = "room_no")
         }
 )
 @Getter

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatMessageRepository.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, String>, ChatMessageQueryRepository {
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE ChatMessage m SET m.unreadCount = m.unreadCount - 1 " +
            "WHERE m.chatRoom.chatRoomNo = :chatRoomNo " +
            "AND m.createdAt > :fromTime " +

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomMemberRepository.java
@@ -5,6 +5,7 @@ import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -34,4 +35,8 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     long countByChatRoom(ChatRoom chatRoom);
 
     boolean existsByChatRoom_ChatRoomNoAndUserNo(String chatRoomNo, String userNo);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ChatRoomMember m WHERE m.chatRoom = :chatRoom")
+    void deleteAllByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomRepository.java
@@ -4,11 +4,13 @@ import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, String>, ChatRoomQueryRepository {
 
     Optional<ChatRoom> findByRoomNoAndChatRoomType(String roomNo, ChatRoomType chatRoomType);
+    List<ChatRoom> findAllByRoomNo(String roomNo);
 
     boolean existsByRoomNo(String roomNo);
 

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomRepository.java
@@ -3,6 +3,9 @@ package com.project.dorumdorum.domain.chat.domain.repository;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +22,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, String>, Cha
 
     Optional<ChatRoom> findByRoomNoAndChatRoomTypeAndApplicantUserNo(
             String roomNo, ChatRoomType chatRoomType, String applicantUserNo);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ChatRoom c WHERE c.chatRoomNo = :chatRoomNo")
+    void deleteByChatRoomNo(@Param("chatRoomNo") String chatRoomNo);
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomMemberService.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomMemberService.java
@@ -65,6 +65,10 @@ public class ChatRoomMemberService {
         chatRoomMemberRepository.delete(member);
     }
 
+    public void deleteAllByChatRoom(ChatRoom chatRoom) {
+        chatRoomMemberRepository.deleteAllByChatRoom(chatRoom);
+    }
+
     public void updateLastReadAt(ChatRoomMember member, LocalDateTime readAt) {
         member.updateLastReadAt(readAt);
         chatRoomMemberRepository.save(member);

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomMemberService.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomMemberService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.project.dorumdorum.global.exception.code.status.ChatErrorStatus.*;
 
@@ -32,6 +33,10 @@ public class ChatRoomMemberService {
     public ChatRoomMember findByChatRoomAndUserNo(ChatRoom chatRoom, String userNo) {
         return chatRoomMemberRepository.findByChatRoomAndUserNo(chatRoom, userNo)
                 .orElseThrow(() -> new RestApiException(CHAT_ROOM_MEMBER_NOT_FOUND));
+    }
+
+    public Optional<ChatRoomMember> findOptionalByChatRoomAndUserNo(ChatRoom chatRoom, String userNo) {
+        return chatRoomMemberRepository.findByChatRoomAndUserNo(chatRoom, userNo);
     }
 
     public ChatRoomMember findByChatRoomNoAndUserNoForUpdate(String chatRoomNo, String userNo) {

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomService.java
@@ -67,6 +67,10 @@ public class ChatRoomService {
         chatRoomRepository.delete(chatRoom);
     }
 
+    public void deleteByChatRoomNo(String chatRoomNo) {
+        chatRoomRepository.deleteByChatRoomNo(chatRoomNo);
+    }
+
     public List<ChatRoom> findAllByRoomNo(String roomNo) {
         return chatRoomRepository.findAllByRoomNo(roomNo);
     }

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomService.java
@@ -67,6 +67,10 @@ public class ChatRoomService {
         chatRoomRepository.delete(chatRoom);
     }
 
+    public List<ChatRoom> findAllByRoomNo(String roomNo) {
+        return chatRoomRepository.findAllByRoomNo(roomNo);
+    }
+
     public List<ChatRoomSummary> findMyChatRooms(String userNo) {
         return chatRoomRepository.findMyChatRooms(userNo);
     }

--- a/src/main/java/com/project/dorumdorum/domain/chat/infra/websocket/ChatWebSocketSendService.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/infra/websocket/ChatWebSocketSendService.java
@@ -1,0 +1,33 @@
+package com.project.dorumdorum.domain.chat.infra.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatWebSocketSendService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Retryable(retryFor = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 2))
+    public void broadcast(String chatRoomNo, Object payload) {
+        messagingTemplate.convertAndSend("/topic/chat-room/" + chatRoomNo, payload);
+    }
+
+    @Retryable(retryFor = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 2))
+    public void notifyUser(String userNo, Object payload) {
+        messagingTemplate.convertAndSendToUser(userNo, "/queue/notification", payload);
+    }
+
+    // broadcast / notifyUser 모두 (String, Object) 시그니처이므로 단일 recover로 처리
+    @Recover
+    public void recoverSend(Exception e, String recipient, Object payload) {
+        log.warn("[Chat] WebSocket 알림 최종 실패. recipient={}", recipient, e);
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/checklist/application/mapper/RoomRuleMapper.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/application/mapper/RoomRuleMapper.java
@@ -22,7 +22,39 @@ public interface RoomRuleMapper {
     @Mapping(target = "room", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    void updateRoomRule(UpdateRoomRuleRequest request, @MappingTarget RoomRule roomRule);
+    default void updateRoomRule(UpdateRoomRuleRequest request, @MappingTarget RoomRule roomRule) {
+        if (request == null || roomRule == null) {
+            return;
+        }
+
+        roomRule.updateChecklist(
+                request.bedtime(),
+                request.wakeUp(),
+                request.returnHome(),
+                request.returnHomeTime(),
+                request.cleaning(),
+                request.phoneCall(),
+                request.sleepLight(),
+                request.sleepHabit(),
+                request.snoring(),
+                request.showerTime(),
+                request.eating(),
+                request.lightsOut(),
+                request.lightsOutTime(),
+                request.homeVisit(),
+                request.smoking(),
+                request.refrigerator(),
+                request.hairDryer(),
+                request.alarm(),
+                request.earphone(),
+                request.keyskin(),
+                request.heat(),
+                request.cold(),
+                request.study(),
+                request.trashCan(),
+                request.otherNotes()
+        );
+    }
 
     MyRoomRuleResponse toResponse(RoomRule roomRule);
 }

--- a/src/main/java/com/project/dorumdorum/domain/checklist/application/mapper/UserChecklistMapper.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/application/mapper/UserChecklistMapper.java
@@ -21,7 +21,39 @@ public interface UserChecklistMapper {
     @Mapping(target = "userNo", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    void updateUserChecklist(UpdateUserChecklistRequest request, @MappingTarget UserChecklist checklist);
+    default void updateUserChecklist(UpdateUserChecklistRequest request, @MappingTarget UserChecklist checklist) {
+        if (request == null || checklist == null) {
+            return;
+        }
+
+        checklist.updateChecklist(
+                request.bedtime(),
+                request.wakeUp(),
+                request.returnHome(),
+                request.returnHomeTime(),
+                request.cleaning(),
+                request.phoneCall(),
+                request.sleepLight(),
+                request.sleepHabit(),
+                request.snoring(),
+                request.showerTime(),
+                request.eating(),
+                request.lightsOut(),
+                request.lightsOutTime(),
+                request.homeVisit(),
+                request.smoking(),
+                request.refrigerator(),
+                request.hairDryer(),
+                request.alarm(),
+                request.earphone(),
+                request.keyskin(),
+                request.heat(),
+                request.cold(),
+                request.study(),
+                request.trashCan(),
+                request.otherNotes()
+        );
+    }
 
     UserChecklistResponse toResponse(UserChecklist checklist);
 }

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/ChecklistBase.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/ChecklistBase.java
@@ -123,6 +123,60 @@ public abstract class ChecklistBase {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    public void updateChecklist(
+            String bedtime,
+            String wakeUp,
+            ReturnHomeType returnHome,
+            String returnHomeTime,
+            CleaningType cleaning,
+            PhoneCallType phoneCall,
+            SleepLightType sleepLight,
+            SleepHabitType sleepHabit,
+            SnoringType snoring,
+            ShowerTimeType showerTime,
+            EatingType eating,
+            LightsOutType lightsOut,
+            String lightsOutTime,
+            HomeVisitType homeVisit,
+            SmokingType smoking,
+            RefrigeratorType refrigerator,
+            String hairDryer,
+            AlarmType alarm,
+            EarphoneType earphone,
+            KeyskinType keyskin,
+            HeatType heat,
+            ColdType cold,
+            StudyType study,
+            TrashCanType trashCan,
+            String otherNotes
+    ) {
+        this.bedtime = bedtime;
+        this.wakeUp = wakeUp;
+        this.returnHome = returnHome;
+        this.returnHomeTime = returnHomeTime;
+        this.cleaning = cleaning;
+        this.phoneCall = phoneCall;
+        this.sleepLight = sleepLight;
+        this.sleepHabit = sleepHabit;
+        this.snoring = snoring;
+        this.showerTime = showerTime;
+        this.eating = eating;
+        this.lightsOut = lightsOut;
+        this.lightsOutTime = lightsOutTime;
+        this.homeVisit = homeVisit;
+        this.smoking = smoking;
+        this.refrigerator = refrigerator;
+        this.hairDryer = hairDryer;
+        this.alarm = alarm;
+        this.earphone = earphone;
+        this.keyskin = keyskin;
+        this.heat = heat;
+        this.cold = cold;
+        this.study = study;
+        this.trashCan = trashCan;
+        this.otherNotes = otherNotes;
+    }
+
     public void updateOtherNotes(String otherNotes) {
         this.otherNotes = otherNotes;
     }

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/repository/RoomRuleRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/repository/RoomRuleRepository.java
@@ -2,6 +2,7 @@ package com.project.dorumdorum.domain.checklist.domain.repository;
 
 import com.project.dorumdorum.domain.checklist.domain.entity.RoomRule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +13,7 @@ public interface RoomRuleRepository extends JpaRepository<RoomRule, String> {
     @Query("select rr from RoomRule rr where rr.room.roomNo = :roomNo")
     Optional<RoomRule> findByRoomNo(@Param("roomNo") String roomNo);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM RoomRule rr WHERE rr.room.roomNo = :roomNo")
+    void deleteByRoomNo(@Param("roomNo") String roomNo);
 }

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/service/RoomRuleService.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/service/RoomRuleService.java
@@ -24,4 +24,8 @@ public class RoomRuleService {
         return roomRuleRepository.findByRoomNo(roomNo)
                 .orElseThrow(() -> new RestApiException(_NOT_FOUND));
     }
+
+    public void deleteByRoomNo(String roomNo) {
+        roomRuleRepository.deleteByRoomNo(roomNo);
+    }
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/application/event/RoomDeletedEvent.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/event/RoomDeletedEvent.java
@@ -1,0 +1,10 @@
+package com.project.dorumdorum.domain.room.application.event;
+
+/**
+ * 방 삭제 → 채팅방 삭제 트리거
+ * 발행 책임: DeleteRoomUseCase (room 도메인 담당자)
+ */
+public record RoomDeletedEvent(
+        String roomNo
+) {
+}

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DeleteRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DeleteRoomUseCase.java
@@ -33,7 +33,8 @@ public class DeleteRoomUseCase {
      * 방 삭제
      * - 방장 권한 검증
      * - 방장 외 룸메이트 존재 시 삭제 불가
-     * - RoomRequest, RoomLike cascade 삭제 후 방 소프트 삭제
+     * - 방 소프트 삭제 → 룸메이트 퇴실 처리 → flush(deletedAt DB 반영)
+     * - RoomRequest, RoomRule, RoomLike 연관 데이터 삭제
      * - 채팅방 삭제 이벤트 발행
      */
     public void execute(String requesterNo, String roomNo) {

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DeleteRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DeleteRoomUseCase.java
@@ -1,0 +1,62 @@
+package com.project.dorumdorum.domain.room.application.usecase;
+
+import com.project.dorumdorum.domain.checklist.domain.service.RoomRuleService;
+import com.project.dorumdorum.domain.room.application.event.RoomDeletedEvent;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
+import com.project.dorumdorum.domain.room.domain.repository.RoomLikeRepository;
+import com.project.dorumdorum.domain.room.domain.service.RoomRequestService;
+import com.project.dorumdorum.domain.room.domain.service.RoomService;
+import com.project.dorumdorum.domain.roommate.domain.service.RoommateService;
+import com.project.dorumdorum.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.project.dorumdorum.global.exception.code.status.RoomErrorStatus.CANNOT_DELETE_COMPLETED_ROOM;
+import static com.project.dorumdorum.global.exception.code.status.RoomErrorStatus.NO_PERMISSION_ON_ROOM;
+import static com.project.dorumdorum.global.exception.code.status.RoomErrorStatus.ROOM_HAS_MEMBERS;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeleteRoomUseCase {
+
+    private final RoomService roomService;
+    private final RoommateService roommateService;
+    private final RoomRequestService roomRequestService;
+    private final RoomRuleService roomRuleService;
+    private final RoomLikeRepository roomLikeRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 방 삭제
+     * - 방장 권한 검증
+     * - 방장 외 룸메이트 존재 시 삭제 불가
+     * - RoomRequest, RoomLike cascade 삭제 후 방 소프트 삭제
+     * - 채팅방 삭제 이벤트 발행
+     */
+    public void execute(String requesterNo, String roomNo) {
+        Room room = roomService.findByIdForUpdate(roomNo);
+
+        if (!room.isHost(requesterNo)) {
+            throw new RestApiException(NO_PERMISSION_ON_ROOM);
+        }
+
+        if (room.isCompleted()) {
+            throw new RestApiException(CANNOT_DELETE_COMPLETED_ROOM);
+        }
+
+        if (room.getCurrentMateCount() > 1) {
+            throw new RestApiException(ROOM_HAS_MEMBERS);
+        }
+
+        roommateService.leaveRoom(requesterNo, roomNo);
+        roomRequestService.deleteAllByRoom(room);
+        roomRuleService.deleteByRoomNo(roomNo);
+        roomLikeRepository.deleteAllByRoom(room);
+        room.delete();
+
+        eventPublisher.publishEvent(new RoomDeletedEvent(roomNo));
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DeleteRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DeleteRoomUseCase.java
@@ -51,11 +51,13 @@ public class DeleteRoomUseCase {
             throw new RestApiException(ROOM_HAS_MEMBERS);
         }
 
+        room.delete();
         roommateService.leaveRoom(requesterNo, roomNo);
+        roomService.flush();
+
         roomRequestService.deleteAllByRoom(room);
         roomRuleService.deleteByRoomNo(roomNo);
         roomLikeRepository.deleteAllByRoom(room);
-        room.delete();
 
         eventPublisher.publishEvent(new RoomDeletedEvent(roomNo));
     }

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/KickRoommateUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/KickRoommateUseCase.java
@@ -41,6 +41,7 @@ public class KickRoommateUseCase {
 
         roommateService.leaveRoom(kickedUserNo, roomNo);
         room.minusCurrentMate();
+        roomService.flush();
 
         eventPublisher.publishEvent(new RoommateKickedEvent(roomNo, kickedUserNo));
     }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomLikeRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomLikeRepository.java
@@ -3,11 +3,18 @@ package com.project.dorumdorum.domain.room.domain.repository;
 import com.project.dorumdorum.domain.room.domain.entity.Room;
 import com.project.dorumdorum.domain.room.domain.entity.RoomLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomLikeRepository extends JpaRepository<RoomLike, String> {
 
     boolean existsByUserNoAndRoom(String userNo, Room room);
-
     void deleteByUserNoAndRoom(String userNo, Room room);
+
+    // N+1 DELETE 문제 — @Modifying JPQL 벌크 DELETE로 교체
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM RoomLike l WHERE l.room = :room")
+    void deleteAllByRoom(@Param("room") Room room);
 }
 

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public interface RoomRepository extends JpaRepository<Room, String>, RoomQueryRepository {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select room from Room room where room.roomNo = :roomNo")
+    @Query("select room from Room room where room.roomNo = :roomNo and room.deletedAt is null")
     Optional<Room> findByRoomNoForUpdate(@Param("roomNo") String roomNo);
 
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomRequestRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomRequestRepository.java
@@ -4,6 +4,9 @@ import com.project.dorumdorum.domain.room.domain.entity.Direction;
 import com.project.dorumdorum.domain.room.domain.entity.Room;
 import com.project.dorumdorum.domain.room.domain.entity.RoomRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,5 +15,9 @@ public interface RoomRequestRepository extends JpaRepository<RoomRequest, String
     boolean existsByUserNoAndRoom(String userNo, Room room);
     Optional<RoomRequest> findByUserNoAndRoomAndDirection(String userNo, Room room, Direction direction);
 
+    // N+1 DELETE 문제 — @Modifying JPQL 벌크 DELETE로 교체
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM RoomRequest r WHERE r.room = :room")
+    void deleteAllByRoom(@Param("room") Room room);
 }
 

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomRequestService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomRequestService.java
@@ -56,4 +56,8 @@ public class RoomRequestService {
 
         roomRequestRepository.delete(request);
     }
+
+    public void deleteAllByRoom(Room room) {
+        roomRequestRepository.deleteAllByRoom(room);
+    }
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
@@ -61,6 +61,10 @@ public class RoomService {
                 .orElseThrow(() -> new RestApiException(ROOM_NOT_FOUND));
     }
 
+    public void flush() {
+        roomRepository.flush();
+    }
+
     public List<FindRoomsResponse> findLikedRooms(String userNo) {
         return roomRepository.findLikedRooms(userNo);
     }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
@@ -13,8 +13,8 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.project.dorumdorum.global.exception.code.status.RoomErrorStatus.ROOM_NOT_FOUND;
 import static com.project.dorumdorum.global.exception.code.status.CommonErrorStatus._NOT_FOUND;
+import static com.project.dorumdorum.global.exception.code.status.RoomErrorStatus.ROOM_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -42,7 +42,7 @@ public class RoomService {
 
     public Room findByIdForUpdate(String roomNo) {
         return roomRepository.findByRoomNoForUpdate(roomNo)
-                .orElseThrow(() -> new RestApiException(_NOT_FOUND));
+                .orElseThrow(() -> new RestApiException(ROOM_NOT_FOUND));
     }
 
     public List<FindRoomsResponse> searchByCursor(

--- a/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/infra/repository/RoomRepositoryImpl.java
@@ -69,6 +69,7 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                 .leftJoin(user).on(user.userNo.eq(room.hostUserNo))
                 .where(
                         room.roomStatus.eq(RoomStatus.CONFIRM_PENDING),
+                        room.deletedAt.isNull(),
                         room.gender.eq(gender),
                         eqRoomType(request),
                         eqResidencePeriod(request),
@@ -147,6 +148,7 @@ public class RoomRepositoryImpl implements RoomQueryRepository {
                 LEFT JOIN users u
                     ON u.user_no = r.host_user_no
                 WHERE r.room_status = :roomStatus
+                  AND r.deleted_at IS NULL
                   AND r.gender = :gender
                 """);
         params.put("roomStatus", RoomStatus.CONFIRM_PENDING.name());

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/DeleteRoomController.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/DeleteRoomController.java
@@ -1,0 +1,25 @@
+package com.project.dorumdorum.domain.room.ui;
+
+import com.project.dorumdorum.domain.room.application.usecase.DeleteRoomUseCase;
+import com.project.dorumdorum.domain.room.ui.spec.DeleteRoomApiSpec;
+import com.project.dorumdorum.global.annotation.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DeleteRoomController implements DeleteRoomApiSpec {
+
+    private final DeleteRoomUseCase deleteRoomUseCase;
+
+    @Override
+    public ResponseEntity<Void> delete(
+            @CurrentUser String requesterNo,
+            @PathVariable String roomNo
+    ) {
+        deleteRoomUseCase.execute(requesterNo, roomNo);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/dorumdorum/domain/room/ui/spec/DeleteRoomApiSpec.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/ui/spec/DeleteRoomApiSpec.java
@@ -1,0 +1,22 @@
+package com.project.dorumdorum.domain.room.ui.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Room")
+public interface DeleteRoomApiSpec {
+
+    @Operation(
+            summary = "방 삭제 API",
+            description = "방장이 방 모집을 삭제합니다. 룸메이트가 없는 경우(방장 단독)에만 삭제 가능합니다."
+    )
+    @DeleteMapping("/api/rooms/{roomNo}")
+    ResponseEntity<Void> delete(
+            @Parameter(hidden = true) String requesterNo,
+            @PathVariable String roomNo
+    );
+}

--- a/src/main/java/com/project/dorumdorum/domain/roommate/domain/service/RoommateService.java
+++ b/src/main/java/com/project/dorumdorum/domain/roommate/domain/service/RoommateService.java
@@ -66,8 +66,8 @@ public class RoommateService {
     public void leaveRoom(String userNo, String roomNo) {
         Roommate roommate = roommateRepository.findByUserNoAndRoomNo(userNo, roomNo)
                 .orElseThrow(() -> new RestApiException(_NOT_FOUND));
+        // uk_roommate_user_no 유니크 제약으로 인해 소프트 삭제 불가 — 하드 삭제 유지
         roommateRepository.delete(roommate);
-        roommateRepository.flush();
     }
 
     public List<MyRoommateResponse> findMyRoommates(String userNo) {

--- a/src/main/java/com/project/dorumdorum/domain/roommate/infra/repository/RoommateRepositoryImpl.java
+++ b/src/main/java/com/project/dorumdorum/domain/roommate/infra/repository/RoommateRepositoryImpl.java
@@ -41,8 +41,16 @@ public class RoommateRepositoryImpl implements RoommateQueryRepository {
                         )
                 )
                 .from(roommate)
-                .join(myRoommate).on(myRoommate.room.eq(roommate.room).and(myRoommate.userNo.eq(userNo)))
+                .join(myRoommate).on(
+                        myRoommate.room.eq(roommate.room)
+                                .and(myRoommate.userNo.eq(userNo))
+                                .and(myRoommate.deletedAt.isNull())
+                )
                 .leftJoin(user).on(user.userNo.eq(roommate.userNo))
+                .where(
+                        roommate.deletedAt.isNull(),
+                        roommate.room.deletedAt.isNull()
+                )
                 .fetch();
     }
 }

--- a/src/main/java/com/project/dorumdorum/global/config/WebSocketConfig.java
+++ b/src/main/java/com/project/dorumdorum/global/config/WebSocketConfig.java
@@ -26,7 +26,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setHandshakeHandler(jwtPrincipalHandshakeHandler)
                 .addInterceptors(jwtHandshakeInterceptor)
                 .setAllowedOriginPatterns("*")
-                .withSockJS(); // HTTP long-polling으로 폴백 시 HTTP 요청으로 처리됌 -> 연결 수 제한 로직 별도 고려 필요
+                .withSockJS(); // HTTP long-polling으로 폴백 시 HTTP 요청으로 처리됨 -> 연결 수 제한 로직 별도 고려 필요
     }
 
     @Override

--- a/src/main/java/com/project/dorumdorum/global/config/WebSocketConfig.java
+++ b/src/main/java/com/project/dorumdorum/global/config/WebSocketConfig.java
@@ -2,6 +2,7 @@ package com.project.dorumdorum.global.config;
 
 import com.project.dorumdorum.global.security.ChatRoomAuthorizationInterceptor;
 import com.project.dorumdorum.global.security.JwtHandshakeInterceptor;
+import com.project.dorumdorum.global.security.JwtPrincipalHandshakeHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -16,11 +17,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+    private final JwtPrincipalHandshakeHandler jwtPrincipalHandshakeHandler;
     private final ChatRoomAuthorizationInterceptor chatRoomAuthorizationInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
+                .setHandshakeHandler(jwtPrincipalHandshakeHandler)
                 .addInterceptors(jwtHandshakeInterceptor)
                 .setAllowedOriginPatterns("*")
                 .withSockJS(); // HTTP long-polling으로 폴백 시 HTTP 요청으로 처리됌 -> 연결 수 제한 로직 별도 고려 필요

--- a/src/main/java/com/project/dorumdorum/global/exception/code/status/RoomErrorStatus.java
+++ b/src/main/java/com/project/dorumdorum/global/exception/code/status/RoomErrorStatus.java
@@ -25,6 +25,8 @@ public enum RoomErrorStatus implements BaseCodeInterface {
     ROOM_FULL(HttpStatus.BAD_REQUEST, "ROOM014", "방 정원이 가득 찼습니다."),
     INVALID_ROOM_CAPACITY(HttpStatus.BAD_REQUEST, "ROOM015", "현재 인원보다 적은 정원으로 변경할 수 없습니다."),
     GENDER_MISMATCH(HttpStatus.FORBIDDEN, "ROOM016", "성별이 다른 방에는 신청할 수 없습니다."),
+    ROOM_HAS_MEMBERS(HttpStatus.BAD_REQUEST, "ROOM017", "룸메이트가 있는 방은 삭제할 수 없습니다."),
+    CANNOT_DELETE_COMPLETED_ROOM(HttpStatus.BAD_REQUEST, "ROOM018", "확정된 방은 삭제할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/dorumdorum/global/security/ChatRoomAuthorizationInterceptor.java
+++ b/src/main/java/com/project/dorumdorum/global/security/ChatRoomAuthorizationInterceptor.java
@@ -6,6 +6,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
@@ -20,14 +21,30 @@ public class ChatRoomAuthorizationInterceptor implements ChannelInterceptor {
     private static final String SEND_SUFFIX = "/send";
 
     /**
-     * STOMP SEND 프레임이 /app/chat-room/{chatRoomNo}/send 로 오면
-     * handshake 때 저장한 userNo 세션 속성이 유효한지 검증.
-     * 채팅방 멤버십 검증은 SendGroupChatMessageUseCase에서 수행.
+     * CONNECT: handshake 때 저장한 userNo를 Spring principal로 등록.
+     *   → convertAndSendToUser(userNo, "/queue/...", payload) 라우팅에 사용됨.
+     * SEND: /app/chat-room/{chatRoomNo}/send 경로의 userNo 세션 속성 유효성 검증.
+     *   채팅방 멤버십 검증은 SendGroupChatMessageUseCase에서 수행.
      */
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-        if (accessor == null || accessor.getCommand() != StompCommand.SEND) return message;
+        if (accessor == null) return message;
+
+        if (accessor.getCommand() == StompCommand.CONNECT) {
+            Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+            if (sessionAttributes != null) {
+                String userNo = (String) sessionAttributes.get("userNo");
+                if (userNo != null) {
+                    StompHeaderAccessor mutableAccessor = StompHeaderAccessor.wrap(message);
+                    mutableAccessor.setUser(new StompPrincipal(userNo));
+                    return MessageBuilder.createMessage(message.getPayload(), mutableAccessor.getMessageHeaders());
+                }
+            }
+            return message;
+        }
+
+        if (accessor.getCommand() != StompCommand.SEND) return message;
 
         String destination = accessor.getDestination();
         if (destination == null

--- a/src/main/java/com/project/dorumdorum/global/security/JwtPrincipalHandshakeHandler.java
+++ b/src/main/java/com/project/dorumdorum/global/security/JwtPrincipalHandshakeHandler.java
@@ -1,0 +1,26 @@
+package com.project.dorumdorum.global.security;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+
+@Component
+public class JwtPrincipalHandshakeHandler extends DefaultHandshakeHandler {
+
+    @Override
+    protected Principal determineUser(
+            ServerHttpRequest request,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes
+    ) {
+        String userNo = (String) attributes.get("userNo");
+        if (userNo != null) {
+            return new StompPrincipal(userNo);
+        }
+        return super.determineUser(request, wsHandler, attributes);
+    }
+}

--- a/src/main/java/com/project/dorumdorum/global/security/StompPrincipal.java
+++ b/src/main/java/com/project/dorumdorum/global/security/StompPrincipal.java
@@ -1,0 +1,11 @@
+package com.project.dorumdorum.global.security;
+
+import java.security.Principal;
+
+public record StompPrincipal(String name) implements Principal {
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -37,3 +37,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_chat_room_group
 CREATE UNIQUE INDEX IF NOT EXISTS uk_chat_room_direct
     ON chat_room (room_no, applicant_user_no)
     WHERE chat_room_type = 'DIRECT';
+
+CREATE INDEX IF NOT EXISTS idx_chat_room_room_no
+    ON chat_room (room_no);

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/ChatWebSocketNotificationEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/ChatWebSocketNotificationEventListenerTest.java
@@ -1,0 +1,41 @@
+package com.project.dorumdorum.domain.chat.unit.usecase;
+
+import com.project.dorumdorum.domain.chat.application.event.ChatWebSocketNotificationEvent;
+import com.project.dorumdorum.domain.chat.application.event.ChatWebSocketNotificationEventListener;
+import com.project.dorumdorum.domain.chat.infra.websocket.ChatWebSocketSendService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.inOrder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatWebSocketNotificationEventListener Unit Tests")
+class ChatWebSocketNotificationEventListenerTest {
+
+    @Mock private ChatWebSocketSendService chatWebSocketSendService;
+    @InjectMocks private ChatWebSocketNotificationEventListener listener;
+
+    @Test
+    @DisplayName("개인 알림을 브로드캐스트보다 먼저 보낸다")
+    void handle_SendsUserNotificationBeforeBroadcast() {
+        Object userPayload = new Object();
+        Object broadcastPayload = new Object();
+        ChatWebSocketNotificationEvent event = new ChatWebSocketNotificationEvent(
+                List.of(new ChatWebSocketNotificationEvent.BroadcastTask("chat-room-1", broadcastPayload)),
+                List.of(new ChatWebSocketNotificationEvent.UserNotifyTask("user-1", userPayload))
+        );
+
+        listener.handle(event);
+
+        InOrder inOrder = inOrder(chatWebSocketSendService);
+        inOrder.verify(chatWebSocketSendService).notifyUser("user-1", userPayload);
+        inOrder.verify(chatWebSocketSendService).broadcast("chat-room-1", broadcastPayload);
+    }
+}

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoomDeletedEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoomDeletedEventListenerTest.java
@@ -1,6 +1,8 @@
 package com.project.dorumdorum.domain.chat.unit.usecase;
 
 import com.project.dorumdorum.domain.chat.application.dto.response.NotificationMessage;
+import com.project.dorumdorum.domain.chat.application.dto.response.NotificationType;
+import com.project.dorumdorum.domain.chat.application.event.ChatWebSocketNotificationEvent;
 import com.project.dorumdorum.domain.chat.application.event.RoomDeletedEventListener;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomType;
@@ -11,15 +13,16 @@ import com.project.dorumdorum.domain.room.application.event.RoomDeletedEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,12 +32,12 @@ class RoomDeletedEventListenerTest {
     @Mock private ChatRoomService chatRoomService;
     @Mock private ChatRoomMemberService chatRoomMemberService;
     @Mock private ChatMessageService chatMessageService;
-    @Mock private SimpMessagingTemplate messagingTemplate;
+    @Mock private ApplicationEventPublisher eventPublisher;
     @InjectMocks private RoomDeletedEventListener listener;
 
     @Test
-    @DisplayName("GROUP 채팅방 — /topic/ 브로드캐스트 후 메시지·멤버·채팅방 순서로 삭제")
-    void handle_GroupChatRoom_BroadcastsAndDeletesInOrder() {
+    @DisplayName("GROUP 채팅방 — 브로드캐스트 이벤트 발행 후 메시지·멤버·채팅방 순서로 삭제")
+    void handle_GroupChatRoom_PublishesEventAndDeletesInOrder() {
         ChatRoom groupRoom = ChatRoom.builder()
                 .chatRoomNo("cr-1").roomNo("r1")
                 .chatRoomType(ChatRoomType.GROUP)
@@ -43,18 +46,25 @@ class RoomDeletedEventListenerTest {
 
         listener.handle(new RoomDeletedEvent("r1"));
 
-        verify(messagingTemplate).convertAndSend(eq("/topic/chat-room/cr-1"), any(NotificationMessage.class));
-        verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any());
-
+        // DB 삭제 순서 검증
         InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService, chatRoomService);
         inOrder.verify(chatMessageService).deleteAllByChatRoom("cr-1");
         inOrder.verify(chatRoomMemberService).deleteAllByChatRoom(groupRoom);
         inOrder.verify(chatRoomService).deleteByChatRoomNo("cr-1");
+
+        // 발행된 이벤트에 GROUP 브로드캐스트 태스크만 있고 개인 알림은 없는지 검증
+        ArgumentCaptor<ChatWebSocketNotificationEvent> captor =
+                ArgumentCaptor.forClass(ChatWebSocketNotificationEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        ChatWebSocketNotificationEvent event = captor.getValue();
+        assertThat(event.broadcasts()).hasSize(1);
+        assertThat(event.broadcasts().get(0).chatRoomNo()).isEqualTo("cr-1");
+        assertThat(event.userNotifications()).isEmpty();
     }
 
     @Test
-    @DisplayName("DIRECT 채팅방 — /topic/ 브로드캐스트 + 지원자에게 /queue/notification 개인 알림")
-    void handle_DirectChatRoom_BroadcastsAndNotifiesApplicant() {
+    @DisplayName("DIRECT 채팅방 — 브로드캐스트 이벤트 + 지원자 개인 알림 태스크 포함")
+    void handle_DirectChatRoom_PublishesEventWithUserNotification() {
         ChatRoom directRoom = ChatRoom.builder()
                 .chatRoomNo("cr-2").roomNo("r1")
                 .chatRoomType(ChatRoomType.DIRECT)
@@ -64,13 +74,24 @@ class RoomDeletedEventListenerTest {
 
         listener.handle(new RoomDeletedEvent("r1"));
 
-        verify(messagingTemplate).convertAndSend(eq("/topic/chat-room/cr-2"), any(NotificationMessage.class));
-        verify(messagingTemplate).convertAndSendToUser(eq("applicant-1"), eq("/queue/notification"), any(NotificationMessage.class));
+        ArgumentCaptor<ChatWebSocketNotificationEvent> captor =
+                ArgumentCaptor.forClass(ChatWebSocketNotificationEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        ChatWebSocketNotificationEvent event = captor.getValue();
+
+        assertThat(event.broadcasts()).hasSize(1);
+        assertThat(event.broadcasts().get(0).chatRoomNo()).isEqualTo("cr-2");
+        assertThat(event.userNotifications()).hasSize(1);
+        assertThat(event.userNotifications().get(0).userNo()).isEqualTo("applicant-1");
+
+        NotificationMessage notification = (NotificationMessage) event.userNotifications().get(0).payload();
+        assertThat(notification.type()).isEqualTo(NotificationType.ROOM_DELETED);
+        assertThat(notification.roomNo()).isEqualTo("r1");
     }
 
     @Test
-    @DisplayName("DIRECT 채팅방에서 applicantUserNo가 null이면 개인 알림 전송 안 함")
-    void handle_DirectChatRoomWithNullApplicant_NoPersonalNotification() {
+    @DisplayName("DIRECT 채팅방에서 applicantUserNo가 null이면 개인 알림 태스크 없음")
+    void handle_DirectChatRoomWithNullApplicant_NoUserNotificationTask() {
         ChatRoom directRoom = ChatRoom.builder()
                 .chatRoomNo("cr-3").roomNo("r1")
                 .chatRoomType(ChatRoomType.DIRECT)
@@ -80,61 +101,27 @@ class RoomDeletedEventListenerTest {
 
         listener.handle(new RoomDeletedEvent("r1"));
 
-        verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any());
+        ArgumentCaptor<ChatWebSocketNotificationEvent> captor =
+                ArgumentCaptor.forClass(ChatWebSocketNotificationEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().userNotifications()).isEmpty();
     }
 
     @Test
-    @DisplayName("채팅방이 없으면 삭제 및 브로드캐스트 없이 종료")
+    @DisplayName("채팅방이 없으면 DB 삭제 및 이벤트 발행 없이 종료")
     void handle_NoChatRooms_DoesNothing() {
         when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of());
 
         listener.handle(new RoomDeletedEvent("r1"));
 
-        verify(messagingTemplate, never()).convertAndSend(any(String.class), any(Object.class));
         verify(chatMessageService, never()).deleteAllByChatRoom(any());
         verify(chatRoomMemberService, never()).deleteAllByChatRoom(any());
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
-    @DisplayName("WebSocket 브로드캐스트 실패 시 예외를 무시하고 삭제 처리 계속 진행")
-    void handle_WebSocketBroadcastFails_ContinuesWithDeletion() {
-        ChatRoom groupRoom = ChatRoom.builder()
-                .chatRoomNo("cr-1").roomNo("r1")
-                .chatRoomType(ChatRoomType.GROUP)
-                .build();
-        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(groupRoom));
-        doThrow(new RuntimeException("WebSocket error"))
-                .when(messagingTemplate).convertAndSend(anyString(), any(Object.class));
-
-        listener.handle(new RoomDeletedEvent("r1"));
-
-        verify(chatMessageService).deleteAllByChatRoom("cr-1");
-        verify(chatRoomMemberService).deleteAllByChatRoom(groupRoom);
-        verify(chatRoomService).deleteByChatRoomNo("cr-1");
-    }
-
-    @Test
-    @DisplayName("개인 알림 전송 실패 시 예외를 무시하고 삭제 처리 계속 진행")
-    void handle_PersonalNotificationFails_ContinuesWithDeletion() {
-        ChatRoom directRoom = ChatRoom.builder()
-                .chatRoomNo("cr-2").roomNo("r1")
-                .chatRoomType(ChatRoomType.DIRECT)
-                .applicantUserNo("applicant-1")
-                .build();
-        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(directRoom));
-        doThrow(new RuntimeException("queue error"))
-                .when(messagingTemplate).convertAndSendToUser(any(), any(), any());
-
-        listener.handle(new RoomDeletedEvent("r1"));
-
-        verify(chatMessageService).deleteAllByChatRoom("cr-2");
-        verify(chatRoomMemberService).deleteAllByChatRoom(directRoom);
-        verify(chatRoomService).deleteByChatRoomNo("cr-2");
-    }
-
-    @Test
-    @DisplayName("복수 채팅방(GROUP + DIRECT)이 있으면 모두 처리")
-    void handle_MultipleRooms_ProcessesAll() {
+    @DisplayName("복수 채팅방(GROUP + DIRECT)이 있으면 이벤트에 모두 포함")
+    void handle_MultipleRooms_EventContainsAllTasks() {
         ChatRoom groupRoom = ChatRoom.builder()
                 .chatRoomNo("cr-1").roomNo("r1")
                 .chatRoomType(ChatRoomType.GROUP)
@@ -150,6 +137,13 @@ class RoomDeletedEventListenerTest {
 
         verify(chatRoomService).deleteByChatRoomNo("cr-1");
         verify(chatRoomService).deleteByChatRoomNo("cr-2");
-        verify(messagingTemplate).convertAndSendToUser(eq("applicant-1"), eq("/queue/notification"), any());
+
+        ArgumentCaptor<ChatWebSocketNotificationEvent> captor =
+                ArgumentCaptor.forClass(ChatWebSocketNotificationEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        ChatWebSocketNotificationEvent event = captor.getValue();
+        assertThat(event.broadcasts()).hasSize(2);
+        assertThat(event.userNotifications()).hasSize(1);
+        assertThat(event.userNotifications().get(0).userNo()).isEqualTo("applicant-1");
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoomDeletedEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoomDeletedEventListenerTest.java
@@ -49,7 +49,7 @@ class RoomDeletedEventListenerTest {
         InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService, chatRoomService);
         inOrder.verify(chatMessageService).deleteAllByChatRoom("cr-1");
         inOrder.verify(chatRoomMemberService).deleteAllByChatRoom(groupRoom);
-        inOrder.verify(chatRoomService).delete(groupRoom);
+        inOrder.verify(chatRoomService).deleteByChatRoomNo("cr-1");
     }
 
     @Test
@@ -110,7 +110,7 @@ class RoomDeletedEventListenerTest {
 
         verify(chatMessageService).deleteAllByChatRoom("cr-1");
         verify(chatRoomMemberService).deleteAllByChatRoom(groupRoom);
-        verify(chatRoomService).delete(groupRoom);
+        verify(chatRoomService).deleteByChatRoomNo("cr-1");
     }
 
     @Test
@@ -129,7 +129,7 @@ class RoomDeletedEventListenerTest {
 
         verify(chatMessageService).deleteAllByChatRoom("cr-2");
         verify(chatRoomMemberService).deleteAllByChatRoom(directRoom);
-        verify(chatRoomService).delete(directRoom);
+        verify(chatRoomService).deleteByChatRoomNo("cr-2");
     }
 
     @Test
@@ -148,8 +148,8 @@ class RoomDeletedEventListenerTest {
 
         listener.handle(new RoomDeletedEvent("r1"));
 
-        verify(chatRoomService).delete(groupRoom);
-        verify(chatRoomService).delete(directRoom);
+        verify(chatRoomService).deleteByChatRoomNo("cr-1");
+        verify(chatRoomService).deleteByChatRoomNo("cr-2");
         verify(messagingTemplate).convertAndSendToUser(eq("applicant-1"), eq("/queue/notification"), any());
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoomDeletedEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoomDeletedEventListenerTest.java
@@ -5,6 +5,7 @@ import com.project.dorumdorum.domain.chat.application.dto.response.NotificationT
 import com.project.dorumdorum.domain.chat.application.event.ChatWebSocketNotificationEvent;
 import com.project.dorumdorum.domain.chat.application.event.RoomDeletedEventListener;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomType;
 import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
 import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
@@ -35,42 +36,18 @@ class RoomDeletedEventListenerTest {
     @Mock private ApplicationEventPublisher eventPublisher;
     @InjectMocks private RoomDeletedEventListener listener;
 
-    @Test
-    @DisplayName("GROUP 채팅방 — 브로드캐스트 이벤트 발행 후 메시지·멤버·채팅방 순서로 삭제")
-    void handle_GroupChatRoom_PublishesEventAndDeletesInOrder() {
-        ChatRoom groupRoom = ChatRoom.builder()
-                .chatRoomNo("cr-1").roomNo("r1")
-                .chatRoomType(ChatRoomType.GROUP)
-                .build();
-        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(groupRoom));
-
-        listener.handle(new RoomDeletedEvent("r1"));
-
-        // DB 삭제 순서 검증
-        InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService, chatRoomService);
-        inOrder.verify(chatMessageService).deleteAllByChatRoom("cr-1");
-        inOrder.verify(chatRoomMemberService).deleteAllByChatRoom(groupRoom);
-        inOrder.verify(chatRoomService).deleteByChatRoomNo("cr-1");
-
-        // 발행된 이벤트에 GROUP 브로드캐스트 태스크만 있고 개인 알림은 없는지 검증
-        ArgumentCaptor<ChatWebSocketNotificationEvent> captor =
-                ArgumentCaptor.forClass(ChatWebSocketNotificationEvent.class);
-        verify(eventPublisher).publishEvent(captor.capture());
-        ChatWebSocketNotificationEvent event = captor.getValue();
-        assertThat(event.broadcasts()).hasSize(1);
-        assertThat(event.broadcasts().get(0).chatRoomNo()).isEqualTo("cr-1");
-        assertThat(event.userNotifications()).isEmpty();
+    private ChatRoomMember memberOf(ChatRoom chatRoom, String userNo) {
+        return ChatRoomMember.builder().chatRoom(chatRoom).userNo(userNo).build();
     }
 
     @Test
-    @DisplayName("DIRECT 채팅방 — 브로드캐스트 이벤트 + 지원자 개인 알림 태스크 포함")
-    void handle_DirectChatRoom_PublishesEventWithUserNotification() {
-        ChatRoom directRoom = ChatRoom.builder()
-                .chatRoomNo("cr-2").roomNo("r1")
-                .chatRoomType(ChatRoomType.DIRECT)
-                .applicantUserNo("applicant-1")
-                .build();
-        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(directRoom));
+    @DisplayName("채팅방 멤버 전원에게 /queue/notification 개인 알림이 발행된다")
+    void handle_NotifiesAllMembersViaUserNotification() {
+        ChatRoom room = ChatRoom.builder().chatRoomNo("cr-1").roomNo("r1")
+                .chatRoomType(ChatRoomType.GROUP).build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(room));
+        when(chatRoomMemberService.findByChatRoom(room))
+                .thenReturn(List.of(memberOf(room, "user-host")));
 
         listener.handle(new RoomDeletedEvent("r1"));
 
@@ -79,32 +56,50 @@ class RoomDeletedEventListenerTest {
         verify(eventPublisher).publishEvent(captor.capture());
         ChatWebSocketNotificationEvent event = captor.getValue();
 
-        assertThat(event.broadcasts()).hasSize(1);
-        assertThat(event.broadcasts().get(0).chatRoomNo()).isEqualTo("cr-2");
+        assertThat(event.broadcasts()).isEmpty();
         assertThat(event.userNotifications()).hasSize(1);
-        assertThat(event.userNotifications().get(0).userNo()).isEqualTo("applicant-1");
+        assertThat(event.userNotifications().get(0).userNo()).isEqualTo("user-host");
 
         NotificationMessage notification = (NotificationMessage) event.userNotifications().get(0).payload();
         assertThat(notification.type()).isEqualTo(NotificationType.ROOM_DELETED);
         assertThat(notification.roomNo()).isEqualTo("r1");
+        assertThat(notification.chatRoomNo()).isEqualTo("cr-1");
     }
 
     @Test
-    @DisplayName("DIRECT 채팅방에서 applicantUserNo가 null이면 개인 알림 태스크 없음")
-    void handle_DirectChatRoomWithNullApplicant_NoUserNotificationTask() {
-        ChatRoom directRoom = ChatRoom.builder()
-                .chatRoomNo("cr-3").roomNo("r1")
-                .chatRoomType(ChatRoomType.DIRECT)
-                .applicantUserNo(null)
-                .build();
+    @DisplayName("DIRECT 채팅방 — 멤버 전원(host + applicant)에게 개인 알림")
+    void handle_DirectChatRoom_NotifiesBothMembers() {
+        ChatRoom directRoom = ChatRoom.builder().chatRoomNo("cr-2").roomNo("r1")
+                .chatRoomType(ChatRoomType.DIRECT).applicantUserNo("applicant-1").build();
         when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(directRoom));
+        when(chatRoomMemberService.findByChatRoom(directRoom))
+                .thenReturn(List.of(memberOf(directRoom, "user-host"), memberOf(directRoom, "applicant-1")));
 
         listener.handle(new RoomDeletedEvent("r1"));
 
         ArgumentCaptor<ChatWebSocketNotificationEvent> captor =
                 ArgumentCaptor.forClass(ChatWebSocketNotificationEvent.class);
         verify(eventPublisher).publishEvent(captor.capture());
-        assertThat(captor.getValue().userNotifications()).isEmpty();
+        ChatWebSocketNotificationEvent event = captor.getValue();
+
+        assertThat(event.broadcasts()).isEmpty();
+        assertThat(event.userNotifications()).hasSize(2);
+        assertThat(event.userNotifications())
+                .extracting(ChatWebSocketNotificationEvent.UserNotifyTask::userNo)
+                .containsExactlyInAnyOrder("user-host", "applicant-1");
+    }
+
+    @Test
+    @DisplayName("멤버가 없는 채팅방이면 이벤트를 발행하지 않는다")
+    void handle_NoMembers_DoesNotPublishEvent() {
+        ChatRoom room = ChatRoom.builder().chatRoomNo("cr-1").roomNo("r1")
+                .chatRoomType(ChatRoomType.GROUP).build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(room));
+        when(chatRoomMemberService.findByChatRoom(room)).thenReturn(List.of());
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
@@ -120,18 +115,34 @@ class RoomDeletedEventListenerTest {
     }
 
     @Test
-    @DisplayName("복수 채팅방(GROUP + DIRECT)이 있으면 이벤트에 모두 포함")
-    void handle_MultipleRooms_EventContainsAllTasks() {
-        ChatRoom groupRoom = ChatRoom.builder()
-                .chatRoomNo("cr-1").roomNo("r1")
-                .chatRoomType(ChatRoomType.GROUP)
-                .build();
-        ChatRoom directRoom = ChatRoom.builder()
-                .chatRoomNo("cr-2").roomNo("r1")
-                .chatRoomType(ChatRoomType.DIRECT)
-                .applicantUserNo("applicant-1")
-                .build();
+    @DisplayName("메시지·멤버·채팅방 순서로 삭제된다")
+    void handle_DeletesInOrder() {
+        ChatRoom room = ChatRoom.builder().chatRoomNo("cr-1").roomNo("r1")
+                .chatRoomType(ChatRoomType.GROUP).build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(room));
+        when(chatRoomMemberService.findByChatRoom(room))
+                .thenReturn(List.of(memberOf(room, "user-host")));
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService, chatRoomService);
+        inOrder.verify(chatMessageService).deleteAllByChatRoom("cr-1");
+        inOrder.verify(chatRoomMemberService).deleteAllByChatRoom(room);
+        inOrder.verify(chatRoomService).deleteByChatRoomNo("cr-1");
+    }
+
+    @Test
+    @DisplayName("복수 채팅방이 있으면 각 채팅방 멤버 모두 알림 수신")
+    void handle_MultipleRooms_AllMembersNotified() {
+        ChatRoom groupRoom = ChatRoom.builder().chatRoomNo("cr-1").roomNo("r1")
+                .chatRoomType(ChatRoomType.GROUP).build();
+        ChatRoom directRoom = ChatRoom.builder().chatRoomNo("cr-2").roomNo("r1")
+                .chatRoomType(ChatRoomType.DIRECT).build();
         when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(groupRoom, directRoom));
+        when(chatRoomMemberService.findByChatRoom(groupRoom))
+                .thenReturn(List.of(memberOf(groupRoom, "user-host")));
+        when(chatRoomMemberService.findByChatRoom(directRoom))
+                .thenReturn(List.of(memberOf(directRoom, "user-host"), memberOf(directRoom, "applicant-1")));
 
         listener.handle(new RoomDeletedEvent("r1"));
 
@@ -142,8 +153,7 @@ class RoomDeletedEventListenerTest {
                 ArgumentCaptor.forClass(ChatWebSocketNotificationEvent.class);
         verify(eventPublisher).publishEvent(captor.capture());
         ChatWebSocketNotificationEvent event = captor.getValue();
-        assertThat(event.broadcasts()).hasSize(2);
-        assertThat(event.userNotifications()).hasSize(1);
-        assertThat(event.userNotifications().get(0).userNo()).isEqualTo("applicant-1");
+        assertThat(event.broadcasts()).isEmpty();
+        assertThat(event.userNotifications()).hasSize(3);
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoomDeletedEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoomDeletedEventListenerTest.java
@@ -1,0 +1,155 @@
+package com.project.dorumdorum.domain.chat.unit.usecase;
+
+import com.project.dorumdorum.domain.chat.application.dto.response.NotificationMessage;
+import com.project.dorumdorum.domain.chat.application.event.RoomDeletedEventListener;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomType;
+import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
+import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
+import com.project.dorumdorum.domain.chat.domain.service.ChatRoomService;
+import com.project.dorumdorum.domain.room.application.event.RoomDeletedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RoomDeletedEventListener Unit Tests")
+class RoomDeletedEventListenerTest {
+
+    @Mock private ChatRoomService chatRoomService;
+    @Mock private ChatRoomMemberService chatRoomMemberService;
+    @Mock private ChatMessageService chatMessageService;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+    @InjectMocks private RoomDeletedEventListener listener;
+
+    @Test
+    @DisplayName("GROUP 채팅방 — /topic/ 브로드캐스트 후 메시지·멤버·채팅방 순서로 삭제")
+    void handle_GroupChatRoom_BroadcastsAndDeletesInOrder() {
+        ChatRoom groupRoom = ChatRoom.builder()
+                .chatRoomNo("cr-1").roomNo("r1")
+                .chatRoomType(ChatRoomType.GROUP)
+                .build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(groupRoom));
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/chat-room/cr-1"), any(NotificationMessage.class));
+        verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any());
+
+        InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService, chatRoomService);
+        inOrder.verify(chatMessageService).deleteAllByChatRoom("cr-1");
+        inOrder.verify(chatRoomMemberService).deleteAllByChatRoom(groupRoom);
+        inOrder.verify(chatRoomService).delete(groupRoom);
+    }
+
+    @Test
+    @DisplayName("DIRECT 채팅방 — /topic/ 브로드캐스트 + 지원자에게 /queue/notification 개인 알림")
+    void handle_DirectChatRoom_BroadcastsAndNotifiesApplicant() {
+        ChatRoom directRoom = ChatRoom.builder()
+                .chatRoomNo("cr-2").roomNo("r1")
+                .chatRoomType(ChatRoomType.DIRECT)
+                .applicantUserNo("applicant-1")
+                .build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(directRoom));
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/chat-room/cr-2"), any(NotificationMessage.class));
+        verify(messagingTemplate).convertAndSendToUser(eq("applicant-1"), eq("/queue/notification"), any(NotificationMessage.class));
+    }
+
+    @Test
+    @DisplayName("DIRECT 채팅방에서 applicantUserNo가 null이면 개인 알림 전송 안 함")
+    void handle_DirectChatRoomWithNullApplicant_NoPersonalNotification() {
+        ChatRoom directRoom = ChatRoom.builder()
+                .chatRoomNo("cr-3").roomNo("r1")
+                .chatRoomType(ChatRoomType.DIRECT)
+                .applicantUserNo(null)
+                .build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(directRoom));
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("채팅방이 없으면 삭제 및 브로드캐스트 없이 종료")
+    void handle_NoChatRooms_DoesNothing() {
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of());
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        verify(messagingTemplate, never()).convertAndSend(any(String.class), any(Object.class));
+        verify(chatMessageService, never()).deleteAllByChatRoom(any());
+        verify(chatRoomMemberService, never()).deleteAllByChatRoom(any());
+    }
+
+    @Test
+    @DisplayName("WebSocket 브로드캐스트 실패 시 예외를 무시하고 삭제 처리 계속 진행")
+    void handle_WebSocketBroadcastFails_ContinuesWithDeletion() {
+        ChatRoom groupRoom = ChatRoom.builder()
+                .chatRoomNo("cr-1").roomNo("r1")
+                .chatRoomType(ChatRoomType.GROUP)
+                .build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(groupRoom));
+        doThrow(new RuntimeException("WebSocket error"))
+                .when(messagingTemplate).convertAndSend(anyString(), any(Object.class));
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        verify(chatMessageService).deleteAllByChatRoom("cr-1");
+        verify(chatRoomMemberService).deleteAllByChatRoom(groupRoom);
+        verify(chatRoomService).delete(groupRoom);
+    }
+
+    @Test
+    @DisplayName("개인 알림 전송 실패 시 예외를 무시하고 삭제 처리 계속 진행")
+    void handle_PersonalNotificationFails_ContinuesWithDeletion() {
+        ChatRoom directRoom = ChatRoom.builder()
+                .chatRoomNo("cr-2").roomNo("r1")
+                .chatRoomType(ChatRoomType.DIRECT)
+                .applicantUserNo("applicant-1")
+                .build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(directRoom));
+        doThrow(new RuntimeException("queue error"))
+                .when(messagingTemplate).convertAndSendToUser(any(), any(), any());
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        verify(chatMessageService).deleteAllByChatRoom("cr-2");
+        verify(chatRoomMemberService).deleteAllByChatRoom(directRoom);
+        verify(chatRoomService).delete(directRoom);
+    }
+
+    @Test
+    @DisplayName("복수 채팅방(GROUP + DIRECT)이 있으면 모두 처리")
+    void handle_MultipleRooms_ProcessesAll() {
+        ChatRoom groupRoom = ChatRoom.builder()
+                .chatRoomNo("cr-1").roomNo("r1")
+                .chatRoomType(ChatRoomType.GROUP)
+                .build();
+        ChatRoom directRoom = ChatRoom.builder()
+                .chatRoomNo("cr-2").roomNo("r1")
+                .chatRoomType(ChatRoomType.DIRECT)
+                .applicantUserNo("applicant-1")
+                .build();
+        when(chatRoomService.findAllByRoomNo("r1")).thenReturn(List.of(groupRoom, directRoom));
+
+        listener.handle(new RoomDeletedEvent("r1"));
+
+        verify(chatRoomService).delete(groupRoom);
+        verify(chatRoomService).delete(directRoom);
+        verify(messagingTemplate).convertAndSendToUser(eq("applicant-1"), eq("/queue/notification"), any());
+    }
+}

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoommateKickedEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoommateKickedEventListenerTest.java
@@ -1,32 +1,30 @@
 package com.project.dorumdorum.domain.chat.unit.usecase;
 
 import com.project.dorumdorum.domain.chat.application.event.RoommateKickedEventListener;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatMessage;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
 import com.project.dorumdorum.domain.chat.domain.entity.MessageType;
 import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
 import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
 import com.project.dorumdorum.domain.chat.domain.service.ChatRoomService;
-import com.project.dorumdorum.domain.chat.domain.entity.ChatMessage;
 import com.project.dorumdorum.domain.room.application.event.RoommateKickedEvent;
 import com.project.dorumdorum.domain.user.domain.entity.User;
 import com.project.dorumdorum.domain.user.domain.service.UserService;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-
-import org.mockito.InOrder;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RoommateKickedEventListener Unit Tests")
@@ -41,20 +39,35 @@ class RoommateKickedEventListenerTest {
 
     private final ChatRoom chatRoom = ChatRoom.builder().roomNo("room-1").build();
 
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private ChatRoomMember givenMember(ChatRoom room, String userNo) {
+        ChatRoomMember member = ChatRoomMember.builder().chatRoom(room).userNo(userNo).build();
+        when(chatRoomMemberService.findOptionalByChatRoomAndUserNo(room, userNo))
+                .thenReturn(Optional.of(member));
+        return member;
+    }
+
+    private ChatMessage givenSystemMessage() {
+        ChatMessage msg = mock(ChatMessage.class);
+        when(msg.getMessageNo()).thenReturn("msg-1");
+        when(msg.getCreatedAt()).thenReturn(LocalDateTime.now());
+        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0)))
+                .thenReturn(msg);
+        return msg;
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────
+
     @Test
     @DisplayName("채팅방에 강퇴 멤버가 있으면 퇴장 처리 및 시스템 메시지 저장")
     void handle_WhenMemberExists_LeavesAndSavesSystemMessage() {
-        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        ChatRoomMember member = givenMember(chatRoom, "user-kicked");
         User mockUser = mock(User.class);
-        ChatMessage mockMessage = mock(ChatMessage.class);
         when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
-        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
         when(userService.findById("user-kicked")).thenReturn(mockUser);
         when(mockUser.getNickname()).thenReturn("kickedNick");
-        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0))).thenReturn(mockMessage);
-        when(mockMessage.getMessageNo()).thenReturn("msg-1");
-        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+        givenSystemMessage();
 
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
 
@@ -77,7 +90,8 @@ class RoommateKickedEventListenerTest {
     @DisplayName("강퇴 유저가 채팅방 멤버가 아니면 아무것도 하지 않는다")
     void handle_WhenNotMember_DoesNothing() {
         when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(false);
+        when(chatRoomMemberService.findOptionalByChatRoomAndUserNo(chatRoom, "user-kicked"))
+                .thenReturn(Optional.empty());
 
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
 
@@ -88,16 +102,15 @@ class RoommateKickedEventListenerTest {
     @Test
     @DisplayName("닉네임이 없으면 이름으로 시스템 메시지 생성")
     void handle_WhenNicknameNull_UsesName() {
-        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        ChatRoomMember member = givenMember(chatRoom, "user-kicked");
         User mockUser = mock(User.class);
         ChatMessage mockMessage = mock(ChatMessage.class);
         when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
-        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
         when(userService.findById("user-kicked")).thenReturn(mockUser);
         when(mockUser.getNickname()).thenReturn(null);
         when(mockUser.getName()).thenReturn("홍길동");
-        when(chatMessageService.save(any(), eq("SYSTEM"), contains("홍길동"), eq(MessageType.SYSTEM), eq(0))).thenReturn(mockMessage);
+        when(chatMessageService.save(any(), eq("SYSTEM"), contains("홍길동"), eq(MessageType.SYSTEM), eq(0)))
+                .thenReturn(mockMessage);
         when(mockMessage.getMessageNo()).thenReturn("msg-1");
         when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
 
@@ -109,21 +122,14 @@ class RoommateKickedEventListenerTest {
     @Test
     @DisplayName("멤버가 존재하면 decreaseUnreadCount가 leave() 이전에 호출된다")
     void handle_WhenMemberExists_DecreasesUnreadCountBeforeLeave() {
-        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        ChatRoomMember member = givenMember(chatRoom, "user-kicked");
         User mockUser = mock(User.class);
-        ChatMessage mockMessage = mock(ChatMessage.class);
         when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
-        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
         when(userService.findById("user-kicked")).thenReturn(mockUser);
         when(mockUser.getNickname()).thenReturn("kickedNick");
-        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0))).thenReturn(mockMessage);
-        when(mockMessage.getMessageNo()).thenReturn("msg-1");
-        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+        givenSystemMessage();
 
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
-
-        verify(chatMessageService).decreaseUnreadCount(any(), any(), eq("user-kicked"));
 
         InOrder inOrder = inOrder(chatMessageService, chatRoomMemberService);
         inOrder.verify(chatMessageService).decreaseUnreadCount(any(), any(), eq("user-kicked"));
@@ -133,39 +139,30 @@ class RoommateKickedEventListenerTest {
     @Test
     @DisplayName("WebSocket 브로드캐스트 실패 시 예외를 무시하고 정상 종료")
     void handle_WhenWebSocketFails_LogsAndContinues() {
-        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        givenMember(chatRoom, "user-kicked");
         User mockUser = mock(User.class);
-        ChatMessage mockMessage = mock(ChatMessage.class);
         when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
-        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
         when(userService.findById("user-kicked")).thenReturn(mockUser);
         when(mockUser.getNickname()).thenReturn("nick");
-        when(chatMessageService.save(any(), any(), any(), any(), anyInt())).thenReturn(mockMessage);
-        when(mockMessage.getMessageNo()).thenReturn("msg-1");
-        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
-        doThrow(new RuntimeException("WebSocket error")).when(messagingTemplate).convertAndSend(anyString(), any(Object.class));
+        givenSystemMessage();
+        doThrow(new RuntimeException("WebSocket error"))
+                .when(messagingTemplate).convertAndSend(anyString(), any(Object.class));
 
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
 
-        verify(chatRoomMemberService).leave(member);
+        verify(chatRoomMemberService).leave(any());
         verify(chatMessageService).save(any(), any(), any(), any(), anyInt());
     }
 
     @Test
     @DisplayName("강퇴 처리 후 강퇴된 사용자에게 /queue/notification 개인 알림 전송")
     void handle_WhenMemberKicked_SendsPersonalNotificationToKickedUser() {
-        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        givenMember(chatRoom, "user-kicked");
         User mockUser = mock(User.class);
-        ChatMessage mockMessage = mock(ChatMessage.class);
         when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
-        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
         when(userService.findById("user-kicked")).thenReturn(mockUser);
         when(mockUser.getNickname()).thenReturn("kickedNick");
-        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0))).thenReturn(mockMessage);
-        when(mockMessage.getMessageNo()).thenReturn("msg-1");
-        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+        givenSystemMessage();
 
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
 
@@ -175,23 +172,18 @@ class RoommateKickedEventListenerTest {
     @Test
     @DisplayName("개인 알림 전송 실패 시 예외를 무시하고 정상 종료")
     void handle_PersonalNotificationFails_LogsAndContinues() {
-        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        givenMember(chatRoom, "user-kicked");
         User mockUser = mock(User.class);
-        ChatMessage mockMessage = mock(ChatMessage.class);
         when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
-        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
         when(userService.findById("user-kicked")).thenReturn(mockUser);
         when(mockUser.getNickname()).thenReturn("nick");
-        when(chatMessageService.save(any(), any(), any(), any(), anyInt())).thenReturn(mockMessage);
-        when(mockMessage.getMessageNo()).thenReturn("msg-1");
-        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+        givenSystemMessage();
         doThrow(new RuntimeException("queue error"))
                 .when(messagingTemplate).convertAndSendToUser(any(), any(), any());
 
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
 
-        verify(chatRoomMemberService).leave(member);
+        verify(chatRoomMemberService).leave(any());
         verify(chatMessageService).save(any(), any(), any(), any(), anyInt());
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoommateKickedEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoommateKickedEventListenerTest.java
@@ -151,4 +151,47 @@ class RoommateKickedEventListenerTest {
         verify(chatRoomMemberService).leave(member);
         verify(chatMessageService).save(any(), any(), any(), any(), anyInt());
     }
+
+    @Test
+    @DisplayName("강퇴 처리 후 강퇴된 사용자에게 /queue/notification 개인 알림 전송")
+    void handle_WhenMemberKicked_SendsPersonalNotificationToKickedUser() {
+        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        User mockUser = mock(User.class);
+        ChatMessage mockMessage = mock(ChatMessage.class);
+        when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
+        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
+        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
+        when(userService.findById("user-kicked")).thenReturn(mockUser);
+        when(mockUser.getNickname()).thenReturn("kickedNick");
+        when(chatMessageService.save(any(), eq("SYSTEM"), anyString(), eq(MessageType.SYSTEM), eq(0))).thenReturn(mockMessage);
+        when(mockMessage.getMessageNo()).thenReturn("msg-1");
+        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
+
+        verify(messagingTemplate).convertAndSendToUser(eq("user-kicked"), eq("/queue/notification"), any());
+    }
+
+    @Test
+    @DisplayName("개인 알림 전송 실패 시 예외를 무시하고 정상 종료")
+    void handle_PersonalNotificationFails_LogsAndContinues() {
+        ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-kicked").build();
+        User mockUser = mock(User.class);
+        ChatMessage mockMessage = mock(ChatMessage.class);
+        when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
+        when(chatRoomMemberService.isMember(chatRoom, "user-kicked")).thenReturn(true);
+        when(chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, "user-kicked")).thenReturn(member);
+        when(userService.findById("user-kicked")).thenReturn(mockUser);
+        when(mockUser.getNickname()).thenReturn("nick");
+        when(chatMessageService.save(any(), any(), any(), any(), anyInt())).thenReturn(mockMessage);
+        when(mockMessage.getMessageNo()).thenReturn("msg-1");
+        when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+        doThrow(new RuntimeException("queue error"))
+                .when(messagingTemplate).convertAndSendToUser(any(), any(), any());
+
+        listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
+
+        verify(chatRoomMemberService).leave(member);
+        verify(chatMessageService).save(any(), any(), any(), any(), anyInt());
+    }
 }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoommateKickedEventListenerTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/usecase/RoommateKickedEventListenerTest.java
@@ -1,5 +1,8 @@
 package com.project.dorumdorum.domain.chat.unit.usecase;
 
+import com.project.dorumdorum.domain.chat.application.dto.response.NotificationMessage;
+import com.project.dorumdorum.domain.chat.application.dto.response.NotificationType;
+import com.project.dorumdorum.domain.chat.application.event.ChatWebSocketNotificationEvent;
 import com.project.dorumdorum.domain.chat.application.event.RoommateKickedEventListener;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatMessage;
 import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
@@ -14,15 +17,17 @@ import com.project.dorumdorum.domain.user.domain.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -34,7 +39,7 @@ class RoommateKickedEventListenerTest {
     @Mock private ChatRoomMemberService chatRoomMemberService;
     @Mock private ChatMessageService chatMessageService;
     @Mock private UserService userService;
-    @Mock private SimpMessagingTemplate messagingTemplate;
+    @Mock private ApplicationEventPublisher eventPublisher;
     @InjectMocks private RoommateKickedEventListener listener;
 
     private final ChatRoom chatRoom = ChatRoom.builder().roomNo("room-1").build();
@@ -84,6 +89,7 @@ class RoommateKickedEventListenerTest {
 
         verify(chatRoomMemberService, never()).leave(any());
         verify(chatMessageService, never()).save(any(), any(), any(), any(), anyInt());
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
@@ -97,6 +103,7 @@ class RoommateKickedEventListenerTest {
 
         verify(chatRoomMemberService, never()).leave(any());
         verify(chatMessageService, never()).save(any(), any(), any(), any(), anyInt());
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
@@ -109,14 +116,14 @@ class RoommateKickedEventListenerTest {
         when(userService.findById("user-kicked")).thenReturn(mockUser);
         when(mockUser.getNickname()).thenReturn(null);
         when(mockUser.getName()).thenReturn("홍길동");
-        when(chatMessageService.save(any(), eq("SYSTEM"), contains("홍길동"), eq(MessageType.SYSTEM), eq(0)))
+        when(chatMessageService.save(any(), eq("SYSTEM"), contains("홍길동님이"), eq(MessageType.SYSTEM), eq(0)))
                 .thenReturn(mockMessage);
         when(mockMessage.getMessageNo()).thenReturn("msg-1");
         when(mockMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
 
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
 
-        verify(chatMessageService).save(eq(chatRoom), eq("SYSTEM"), contains("홍길동"), eq(MessageType.SYSTEM), eq(0));
+        verify(chatMessageService).save(eq(chatRoom), eq("SYSTEM"), contains("홍길동님이"), eq(MessageType.SYSTEM), eq(0));
     }
 
     @Test
@@ -137,26 +144,8 @@ class RoommateKickedEventListenerTest {
     }
 
     @Test
-    @DisplayName("WebSocket 브로드캐스트 실패 시 예외를 무시하고 정상 종료")
-    void handle_WhenWebSocketFails_LogsAndContinues() {
-        givenMember(chatRoom, "user-kicked");
-        User mockUser = mock(User.class);
-        when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(userService.findById("user-kicked")).thenReturn(mockUser);
-        when(mockUser.getNickname()).thenReturn("nick");
-        givenSystemMessage();
-        doThrow(new RuntimeException("WebSocket error"))
-                .when(messagingTemplate).convertAndSend(anyString(), any(Object.class));
-
-        listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
-
-        verify(chatRoomMemberService).leave(any());
-        verify(chatMessageService).save(any(), any(), any(), any(), anyInt());
-    }
-
-    @Test
-    @DisplayName("강퇴 처리 후 강퇴된 사용자에게 /queue/notification 개인 알림 전송")
-    void handle_WhenMemberKicked_SendsPersonalNotificationToKickedUser() {
+    @DisplayName("강퇴 처리 후 이벤트에 브로드캐스트 + 강퇴 사용자 개인 알림 태스크가 담긴다")
+    void handle_WhenMemberKicked_PublishesEventWithBroadcastAndUserNotification() {
         givenMember(chatRoom, "user-kicked");
         User mockUser = mock(User.class);
         when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
@@ -166,24 +155,17 @@ class RoommateKickedEventListenerTest {
 
         listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
 
-        verify(messagingTemplate).convertAndSendToUser(eq("user-kicked"), eq("/queue/notification"), any());
-    }
+        ArgumentCaptor<ChatWebSocketNotificationEvent> captor =
+                ArgumentCaptor.forClass(ChatWebSocketNotificationEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        ChatWebSocketNotificationEvent event = captor.getValue();
 
-    @Test
-    @DisplayName("개인 알림 전송 실패 시 예외를 무시하고 정상 종료")
-    void handle_PersonalNotificationFails_LogsAndContinues() {
-        givenMember(chatRoom, "user-kicked");
-        User mockUser = mock(User.class);
-        when(chatRoomService.findByRoomNo("room-1")).thenReturn(Optional.of(chatRoom));
-        when(userService.findById("user-kicked")).thenReturn(mockUser);
-        when(mockUser.getNickname()).thenReturn("nick");
-        givenSystemMessage();
-        doThrow(new RuntimeException("queue error"))
-                .when(messagingTemplate).convertAndSendToUser(any(), any(), any());
+        assertThat(event.broadcasts()).hasSize(1);
+        assertThat(event.userNotifications()).hasSize(1);
+        assertThat(event.userNotifications().get(0).userNo()).isEqualTo("user-kicked");
 
-        listener.handle(new RoommateKickedEvent("room-1", "user-kicked"));
-
-        verify(chatRoomMemberService).leave(any());
-        verify(chatMessageService).save(any(), any(), any(), any(), anyInt());
+        NotificationMessage notification = (NotificationMessage) event.userNotifications().get(0).payload();
+        assertThat(notification.type()).isEqualTo(NotificationType.KICKED_FROM_ROOM);
+        assertThat(notification.roomNo()).isEqualTo("room-1");
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/checklist/unit/mapper/RoomRuleMapperTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/checklist/unit/mapper/RoomRuleMapperTest.java
@@ -33,14 +33,34 @@ class RoomRuleMapperTest {
     void updateRoomRule_UpdatesTarget() {
         RoomRule target = mapper.toRoomRule(room, ChecklistFixtures.createRoomRuleRequest());
         UpdateRoomRuleRequest request = ChecklistFixtures.updateRoomRuleRequest();
-        String bedtimeBefore = target.getBedtime();
-        String notesBefore = target.getOtherNotes();
 
         mapper.updateRoomRule(request, target);
 
-        // Current MapStruct output generates no-op updater for this entity.
-        assertThat(target.getBedtime()).isEqualTo(bedtimeBefore);
-        assertThat(target.getOtherNotes()).isEqualTo(notesBefore);
+        assertThat(target.getBedtime()).isEqualTo(request.bedtime());
+        assertThat(target.getWakeUp()).isEqualTo(request.wakeUp());
+        assertThat(target.getReturnHome()).isEqualTo(request.returnHome());
+        assertThat(target.getReturnHomeTime()).isEqualTo(request.returnHomeTime());
+        assertThat(target.getCleaning()).isEqualTo(request.cleaning());
+        assertThat(target.getPhoneCall()).isEqualTo(request.phoneCall());
+        assertThat(target.getSleepLight()).isEqualTo(request.sleepLight());
+        assertThat(target.getSleepHabit()).isEqualTo(request.sleepHabit());
+        assertThat(target.getSnoring()).isEqualTo(request.snoring());
+        assertThat(target.getShowerTime()).isEqualTo(request.showerTime());
+        assertThat(target.getEating()).isEqualTo(request.eating());
+        assertThat(target.getLightsOut()).isEqualTo(request.lightsOut());
+        assertThat(target.getLightsOutTime()).isEqualTo(request.lightsOutTime());
+        assertThat(target.getHomeVisit()).isEqualTo(request.homeVisit());
+        assertThat(target.getSmoking()).isEqualTo(request.smoking());
+        assertThat(target.getRefrigerator()).isEqualTo(request.refrigerator());
+        assertThat(target.getHairDryer()).isEqualTo(request.hairDryer());
+        assertThat(target.getAlarm()).isEqualTo(request.alarm());
+        assertThat(target.getEarphone()).isEqualTo(request.earphone());
+        assertThat(target.getKeyskin()).isEqualTo(request.keyskin());
+        assertThat(target.getHeat()).isEqualTo(request.heat());
+        assertThat(target.getCold()).isEqualTo(request.cold());
+        assertThat(target.getStudy()).isEqualTo(request.study());
+        assertThat(target.getTrashCan()).isEqualTo(request.trashCan());
+        assertThat(target.getOtherNotes()).isEqualTo(request.otherNotes());
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/domain/checklist/unit/mapper/UserChecklistMapperTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/checklist/unit/mapper/UserChecklistMapperTest.java
@@ -31,14 +31,34 @@ class UserChecklistMapperTest {
     void updateUserChecklist_UpdatesTarget() {
         UserChecklist target = mapper.toUserChecklist("u1", ChecklistFixtures.createUserChecklistRequest());
         UpdateUserChecklistRequest request = ChecklistFixtures.updateUserChecklistRequest();
-        String bedtimeBefore = target.getBedtime();
-        String notesBefore = target.getOtherNotes();
 
         mapper.updateUserChecklist(request, target);
 
-        // Current MapStruct output generates no-op updater for this entity.
-        assertThat(target.getBedtime()).isEqualTo(bedtimeBefore);
-        assertThat(target.getOtherNotes()).isEqualTo(notesBefore);
+        assertThat(target.getBedtime()).isEqualTo(request.bedtime());
+        assertThat(target.getWakeUp()).isEqualTo(request.wakeUp());
+        assertThat(target.getReturnHome()).isEqualTo(request.returnHome());
+        assertThat(target.getReturnHomeTime()).isEqualTo(request.returnHomeTime());
+        assertThat(target.getCleaning()).isEqualTo(request.cleaning());
+        assertThat(target.getPhoneCall()).isEqualTo(request.phoneCall());
+        assertThat(target.getSleepLight()).isEqualTo(request.sleepLight());
+        assertThat(target.getSleepHabit()).isEqualTo(request.sleepHabit());
+        assertThat(target.getSnoring()).isEqualTo(request.snoring());
+        assertThat(target.getShowerTime()).isEqualTo(request.showerTime());
+        assertThat(target.getEating()).isEqualTo(request.eating());
+        assertThat(target.getLightsOut()).isEqualTo(request.lightsOut());
+        assertThat(target.getLightsOutTime()).isEqualTo(request.lightsOutTime());
+        assertThat(target.getHomeVisit()).isEqualTo(request.homeVisit());
+        assertThat(target.getSmoking()).isEqualTo(request.smoking());
+        assertThat(target.getRefrigerator()).isEqualTo(request.refrigerator());
+        assertThat(target.getHairDryer()).isEqualTo(request.hairDryer());
+        assertThat(target.getAlarm()).isEqualTo(request.alarm());
+        assertThat(target.getEarphone()).isEqualTo(request.earphone());
+        assertThat(target.getKeyskin()).isEqualTo(request.keyskin());
+        assertThat(target.getHeat()).isEqualTo(request.heat());
+        assertThat(target.getCold()).isEqualTo(request.cold());
+        assertThat(target.getStudy()).isEqualTo(request.study());
+        assertThat(target.getTrashCan()).isEqualTo(request.trashCan());
+        assertThat(target.getOtherNotes()).isEqualTo(request.otherNotes());
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/DeleteRoomPersistenceIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/DeleteRoomPersistenceIntegrationTest.java
@@ -25,10 +25,6 @@ import com.project.dorumdorum.domain.roommate.domain.entity.ConfirmStatus;
 import com.project.dorumdorum.domain.roommate.domain.entity.RoomRole;
 import com.project.dorumdorum.domain.roommate.domain.entity.Roommate;
 import com.project.dorumdorum.domain.roommate.domain.repository.RoommateRepository;
-import com.project.dorumdorum.domain.user.domain.entity.Gender;
-import com.project.dorumdorum.domain.user.domain.entity.Role;
-import com.project.dorumdorum.domain.user.domain.entity.User;
-import com.project.dorumdorum.domain.user.domain.repository.UserRepository;
 import com.project.dorumdorum.testsupport.TestcontainersSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -44,6 +40,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * userNo에 FK 제약이 없으므로 실제 User 엔티티 없이 임의 ID 사용 가능.
+ * '_delete_room_' 접두사로 다른 테스트 데이터와 충돌 방지.
+ */
 @SpringBootTest
 @ActiveProfiles("test")
 @DisplayName("DeleteRoom 영속성 통합 테스트")
@@ -62,7 +62,6 @@ class DeleteRoomPersistenceIntegrationTest {
     @MockitoBean private SimpMessagingTemplate messagingTemplate;
 
     @Autowired private DeleteRoomUseCase deleteRoomUseCase;
-    @Autowired private UserRepository userRepository;
     @Autowired private RoomRepository roomRepository;
     @Autowired private RoommateRepository roommateRepository;
     @Autowired private RoomRequestRepository roomRequestRepository;
@@ -71,41 +70,20 @@ class DeleteRoomPersistenceIntegrationTest {
     @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
     @Autowired private ChatMessageRepository chatMessageRepository;
 
-    private static final String HOST_NO = "delete-host-001";
-    private static final String APPLICANT_NO = "delete-applicant-001";
+    private static final String HOST_NO      = "test_delete_room_host_001";
+    private static final String APPLICANT_NO = "test_delete_room_applicant_001";
 
     private Room room;
 
     @BeforeEach
     void setUp() {
-        userRepository.save(User.builder()
-                .userNo(HOST_NO)
-                .email("delete-host@gachon.ac.kr")
-                .password("pw")
-                .role(Role.USER)
-                .studentNo("202400201")
-                .name("DeleteHost")
-                .nickname("DeleteHostNick")
-                .gender(Gender.MALE)
-                .build());
-        userRepository.save(User.builder()
-                .userNo(APPLICANT_NO)
-                .email("delete-applicant@gachon.ac.kr")
-                .password("pw")
-                .role(Role.USER)
-                .studentNo("202400202")
-                .name("DeleteApplicant")
-                .nickname("DeleteApplicantNick")
-                .gender(Gender.MALE)
-                .build());
-
         room = roomRepository.save(Room.builder()
                 .roomType(RoomType.TYPE_1)
                 .capacity(2)
                 .title("delete-room")
                 .hostUserNo(HOST_NO)
                 .residencePeriod(ResidencePeriod.SEMESTER)
-                .gender(Gender.MALE)
+                .gender(com.project.dorumdorum.domain.user.domain.entity.Gender.MALE)
                 .build());
 
         roommateRepository.save(Roommate.builder()
@@ -182,14 +160,13 @@ class DeleteRoomPersistenceIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        chatMessageRepository.deleteAll();
-        chatRoomMemberRepository.deleteAll();
-        chatRoomRepository.deleteAll();
-        roomRequestRepository.deleteAll();
-        roomRuleRepository.deleteAll();
-        roommateRepository.deleteAll();
-        roomRepository.deleteAll();
-        userRepository.deleteAll();
+        chatMessageRepository.deleteAllInBatch();
+        chatRoomMemberRepository.deleteAllInBatch();
+        chatRoomRepository.deleteAllInBatch();
+        roomRequestRepository.deleteAllInBatch();
+        roomRuleRepository.deleteAllInBatch();
+        roommateRepository.deleteAllInBatch();
+        roomRepository.deleteAllInBatch();
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/DeleteRoomPersistenceIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/DeleteRoomPersistenceIntegrationTest.java
@@ -38,7 +38,12 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * userNo에 FK 제약이 없으므로 실제 User 엔티티 없이 임의 ID 사용 가능.
@@ -183,5 +188,9 @@ class DeleteRoomPersistenceIntegrationTest {
         assertThat(chatRoomRepository.findAllByRoomNo(room.getRoomNo())).isEmpty();
         assertThat(chatRoomMemberRepository.findAll()).isEmpty();
         assertThat(chatMessageRepository.findAll()).isEmpty();
+
+        await().untilAsserted(() ->
+                verify(messagingTemplate, times(3))
+                        .convertAndSendToUser(any(), eq("/queue/notification"), any()));
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/DeleteRoomPersistenceIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/DeleteRoomPersistenceIntegrationTest.java
@@ -1,0 +1,210 @@
+package com.project.dorumdorum.domain.room.integration;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatMessage;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomType;
+import com.project.dorumdorum.domain.chat.domain.entity.MessageType;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatMessageRepository;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatRoomMemberRepository;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatRoomRepository;
+import com.project.dorumdorum.domain.checklist.domain.entity.RoomRule;
+import com.project.dorumdorum.domain.checklist.domain.entity.enums.*;
+import com.project.dorumdorum.domain.checklist.domain.repository.RoomRuleRepository;
+import com.project.dorumdorum.domain.room.application.usecase.DeleteRoomUseCase;
+import com.project.dorumdorum.domain.room.domain.entity.Direction;
+import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
+import com.project.dorumdorum.domain.room.domain.entity.RoomRequest;
+import com.project.dorumdorum.domain.room.domain.entity.RoomType;
+import com.project.dorumdorum.domain.room.domain.repository.RoomRequestRepository;
+import com.project.dorumdorum.domain.room.domain.repository.RoomRepository;
+import com.project.dorumdorum.domain.roommate.domain.entity.ConfirmStatus;
+import com.project.dorumdorum.domain.roommate.domain.entity.RoomRole;
+import com.project.dorumdorum.domain.roommate.domain.entity.Roommate;
+import com.project.dorumdorum.domain.roommate.domain.repository.RoommateRepository;
+import com.project.dorumdorum.domain.user.domain.entity.Gender;
+import com.project.dorumdorum.domain.user.domain.entity.Role;
+import com.project.dorumdorum.domain.user.domain.entity.User;
+import com.project.dorumdorum.domain.user.domain.repository.UserRepository;
+import com.project.dorumdorum.testsupport.TestcontainersSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("DeleteRoom 영속성 통합 테스트")
+class DeleteRoomPersistenceIntegrationTest {
+
+    @BeforeAll
+    static void requireDocker() {
+        Assumptions.assumeTrue(
+                TestcontainersSupport.requireDockerOrSkip("DeleteRoomPersistenceIntegrationTest"),
+                "Docker is required for DeleteRoomPersistenceIntegrationTest"
+        );
+    }
+
+    @MockitoBean private FirebaseApp firebaseApp;
+    @MockitoBean private FirebaseMessaging firebaseMessaging;
+    @MockitoBean private SimpMessagingTemplate messagingTemplate;
+
+    @Autowired private DeleteRoomUseCase deleteRoomUseCase;
+    @Autowired private UserRepository userRepository;
+    @Autowired private RoomRepository roomRepository;
+    @Autowired private RoommateRepository roommateRepository;
+    @Autowired private RoomRequestRepository roomRequestRepository;
+    @Autowired private RoomRuleRepository roomRuleRepository;
+    @Autowired private ChatRoomRepository chatRoomRepository;
+    @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired private ChatMessageRepository chatMessageRepository;
+
+    private static final String HOST_NO = "delete-host-001";
+    private static final String APPLICANT_NO = "delete-applicant-001";
+
+    private Room room;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.save(User.builder()
+                .userNo(HOST_NO)
+                .email("delete-host@gachon.ac.kr")
+                .password("pw")
+                .role(Role.USER)
+                .studentNo("202400201")
+                .name("DeleteHost")
+                .nickname("DeleteHostNick")
+                .gender(Gender.MALE)
+                .build());
+        userRepository.save(User.builder()
+                .userNo(APPLICANT_NO)
+                .email("delete-applicant@gachon.ac.kr")
+                .password("pw")
+                .role(Role.USER)
+                .studentNo("202400202")
+                .name("DeleteApplicant")
+                .nickname("DeleteApplicantNick")
+                .gender(Gender.MALE)
+                .build());
+
+        room = roomRepository.save(Room.builder()
+                .roomType(RoomType.TYPE_1)
+                .capacity(2)
+                .title("delete-room")
+                .hostUserNo(HOST_NO)
+                .residencePeriod(ResidencePeriod.SEMESTER)
+                .gender(Gender.MALE)
+                .build());
+
+        roommateRepository.save(Roommate.builder()
+                .room(room)
+                .userNo(HOST_NO)
+                .roomRole(RoomRole.HOST)
+                .confirmStatus(ConfirmStatus.PENDING)
+                .build());
+
+        roomRuleRepository.save(RoomRule.builder()
+                .room(room)
+                .bedtime("23:30")
+                .wakeUp("07:30")
+                .returnHome(ReturnHomeType.FLEXIBLE)
+                .returnHomeTime("22:00")
+                .cleaning(CleaningType.REGULAR)
+                .phoneCall(PhoneCallType.ALLOWED)
+                .sleepLight(SleepLightType.DARK)
+                .sleepHabit(SleepHabitType.MILD)
+                .snoring(SnoringType.MILD_OR_NONE)
+                .showerTime(ShowerTimeType.EVENING)
+                .eating(EatingType.ALLOWED_WITH_VENTILATION)
+                .lightsOut(LightsOutType.AFTER_TIME)
+                .lightsOutTime("00:30")
+                .homeVisit(HomeVisitType.MONTHLY_OR_MORE)
+                .smoking(SmokingType.NON_SMOKER)
+                .refrigerator(RefrigeratorType.DECIDE_AFTER_DISCUSSION)
+                .hairDryer("FLEXIBLE")
+                .alarm(AlarmType.VIBRATION)
+                .earphone(EarphoneType.FLEXIBLE)
+                .keyskin(KeyskinType.FLEXIBLE)
+                .heat(HeatType.MODERATE)
+                .cold(ColdType.MODERATE)
+                .study(StudyType.FLEXIBLE)
+                .trashCan(TrashCanType.SHARED)
+                .otherNotes("delete test")
+                .build());
+
+        roomRequestRepository.save(RoomRequest.builder()
+                .room(room)
+                .userNo(APPLICANT_NO)
+                .direction(Direction.USER_TO_ROOM)
+                .introduction("please")
+                .additionalMessage("delete me")
+                .build());
+
+        ChatRoom directChatRoom = chatRoomRepository.save(ChatRoom.builder()
+                .roomNo(room.getRoomNo())
+                .chatRoomType(ChatRoomType.DIRECT)
+                .applicantUserNo(APPLICANT_NO)
+                .build());
+        ChatRoom groupChatRoom = chatRoomRepository.save(ChatRoom.builder()
+                .roomNo(room.getRoomNo())
+                .chatRoomType(ChatRoomType.GROUP)
+                .build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().chatRoom(directChatRoom).userNo(HOST_NO).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().chatRoom(directChatRoom).userNo(APPLICANT_NO).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().chatRoom(groupChatRoom).userNo(HOST_NO).build());
+        chatMessageRepository.save(ChatMessage.builder()
+                .chatRoom(directChatRoom)
+                .senderNo(HOST_NO)
+                .content("hello")
+                .messageType(MessageType.TEXT)
+                .unreadCount(1)
+                .build());
+        chatMessageRepository.save(ChatMessage.builder()
+                .chatRoom(groupChatRoom)
+                .senderNo(HOST_NO)
+                .content("group hello")
+                .messageType(MessageType.TEXT)
+                .unreadCount(0)
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        chatMessageRepository.deleteAll();
+        chatRoomMemberRepository.deleteAll();
+        chatRoomRepository.deleteAll();
+        roomRequestRepository.deleteAll();
+        roomRuleRepository.deleteAll();
+        roommateRepository.deleteAll();
+        roomRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("삭제 성공 시 room은 soft delete 되고 연관 요청/규칙/채팅은 정리된다")
+    void execute_PersistsSoftDeleteAndCleanup() {
+        deleteRoomUseCase.execute(HOST_NO, room.getRoomNo());
+
+        Room persistedRoom = roomRepository.findById(room.getRoomNo()).orElseThrow();
+
+        assertThat(persistedRoom.getDeletedAt()).isNotNull();
+        assertThat(roommateRepository.findByUserNo(HOST_NO)).isEmpty();
+        assertThat(roomRequestRepository.findAll()).isEmpty();
+        assertThat(roomRuleRepository.findByRoomNo(room.getRoomNo())).isEmpty();
+        assertThat(chatRoomRepository.findAllByRoomNo(room.getRoomNo())).isEmpty();
+        assertThat(chatRoomMemberRepository.findAll()).isEmpty();
+        assertThat(chatMessageRepository.findAll()).isEmpty();
+    }
+}

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/KickRoommatePersistenceIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/KickRoommatePersistenceIntegrationTest.java
@@ -38,6 +38,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.time.LocalDateTime;
 
+import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -165,6 +166,10 @@ class KickRoommatePersistenceIntegrationTest {
         assertThat(persistedRoom.getCurrentMateCount()).isEqualTo(1);
         assertThat(persistedRoom.getRemaining()).isEqualTo(1);
 
-        verify(messagingTemplate).convertAndSendToUser(eq(MEMBER_NO), eq("/queue/notification"), any());
+        await().untilAsserted(() -> {
+            verify(messagingTemplate).convertAndSend(
+                    eq("/topic/chat-room/" + chatRoom.getChatRoomNo()), any(Object.class));
+            verify(messagingTemplate).convertAndSendToUser(eq(MEMBER_NO), eq("/queue/notification"), any());
+        });
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/KickRoommatePersistenceIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/KickRoommatePersistenceIntegrationTest.java
@@ -1,0 +1,173 @@
+package com.project.dorumdorum.domain.room.integration;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatMessage;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
+import com.project.dorumdorum.domain.chat.domain.entity.MessageType;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatMessageRepository;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatRoomMemberRepository;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatRoomRepository;
+import com.project.dorumdorum.domain.room.application.usecase.KickRoommateUseCase;
+import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
+import com.project.dorumdorum.domain.room.domain.entity.RoomType;
+import com.project.dorumdorum.domain.room.domain.repository.RoomRepository;
+import com.project.dorumdorum.domain.roommate.domain.entity.ConfirmStatus;
+import com.project.dorumdorum.domain.roommate.domain.entity.RoomRole;
+import com.project.dorumdorum.domain.roommate.domain.entity.Roommate;
+import com.project.dorumdorum.domain.roommate.domain.repository.RoommateRepository;
+import com.project.dorumdorum.domain.user.domain.entity.Gender;
+import com.project.dorumdorum.domain.user.domain.entity.Role;
+import com.project.dorumdorum.domain.user.domain.entity.User;
+import com.project.dorumdorum.domain.user.domain.repository.UserRepository;
+import com.project.dorumdorum.testsupport.TestcontainersSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("KickRoommate 영속성 통합 테스트")
+class KickRoommatePersistenceIntegrationTest {
+
+    @BeforeAll
+    static void requireDocker() {
+        Assumptions.assumeTrue(
+                TestcontainersSupport.requireDockerOrSkip("KickRoommatePersistenceIntegrationTest"),
+                "Docker is required for KickRoommatePersistenceIntegrationTest"
+        );
+    }
+
+    @MockitoBean private FirebaseApp firebaseApp;
+    @MockitoBean private FirebaseMessaging firebaseMessaging;
+    @MockitoBean private SimpMessagingTemplate messagingTemplate;
+
+    @Autowired private KickRoommateUseCase kickRoommateUseCase;
+    @Autowired private UserRepository userRepository;
+    @Autowired private RoomRepository roomRepository;
+    @Autowired private RoommateRepository roommateRepository;
+    @Autowired private ChatRoomRepository chatRoomRepository;
+    @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired private ChatMessageRepository chatMessageRepository;
+
+    private static final String HOST_NO = "kick-host-001";
+    private static final String MEMBER_NO = "kick-member-001";
+
+    private Room room;
+    private ChatRoom chatRoom;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.save(User.builder()
+                .userNo(HOST_NO)
+                .email("kick-host@gachon.ac.kr")
+                .password("pw")
+                .role(Role.USER)
+                .studentNo("202400101")
+                .name("Host")
+                .nickname("HostNick")
+                .gender(Gender.MALE)
+                .build());
+        userRepository.save(User.builder()
+                .userNo(MEMBER_NO)
+                .email("kick-member@gachon.ac.kr")
+                .password("pw")
+                .role(Role.USER)
+                .studentNo("202400102")
+                .name("Member")
+                .nickname("MemberNick")
+                .gender(Gender.MALE)
+                .build());
+
+        room = roomRepository.save(Room.builder()
+                .roomType(RoomType.TYPE_1)
+                .capacity(2)
+                .title("kick-room")
+                .hostUserNo(HOST_NO)
+                .residencePeriod(ResidencePeriod.SEMESTER)
+                .gender(Gender.MALE)
+                .build());
+        room.plusCurrentMate();
+
+        roommateRepository.save(Roommate.builder()
+                .room(room)
+                .userNo(HOST_NO)
+                .roomRole(RoomRole.HOST)
+                .confirmStatus(ConfirmStatus.ACCEPTED)
+                .build());
+        roommateRepository.save(Roommate.builder()
+                .room(room)
+                .userNo(MEMBER_NO)
+                .roomRole(RoomRole.MEMBER)
+                .confirmStatus(ConfirmStatus.ACCEPTED)
+                .build());
+
+        chatRoom = chatRoomRepository.save(ChatRoom.builder()
+                .roomNo(room.getRoomNo())
+                .build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().chatRoom(chatRoom).userNo(HOST_NO).build());
+        ChatRoomMember memberChat = chatRoomMemberRepository.save(
+                ChatRoomMember.builder().chatRoom(chatRoom).userNo(MEMBER_NO).build()
+        );
+
+        chatMessageRepository.save(ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .senderNo(HOST_NO)
+                .content("hello")
+                .messageType(MessageType.TEXT)
+                .unreadCount(1)
+                .build());
+        chatMessageRepository.save(ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .senderNo("SYSTEM")
+                .content("joined")
+                .messageType(MessageType.SYSTEM)
+                .unreadCount(0)
+                .build());
+
+        memberChat.updateLastReadAt(LocalDateTime.now().minusMinutes(1));
+        chatRoomMemberRepository.save(memberChat);
+    }
+
+    @AfterEach
+    void tearDown() {
+        chatMessageRepository.deleteAll();
+        chatRoomMemberRepository.deleteAll();
+        chatRoomRepository.deleteAll();
+        roommateRepository.deleteAll();
+        roomRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("강퇴 성공 시 룸메이트/채팅멤버/인원수가 실제 DB에 반영된다")
+    void execute_PersistsKickChangesAcrossRoomAndChat() {
+        kickRoommateUseCase.execute(HOST_NO, room.getRoomNo(), MEMBER_NO);
+
+        Room persistedRoom = roomRepository.findById(room.getRoomNo()).orElseThrow();
+
+        assertThat(roommateRepository.existsByUserNoAndRoomNo(MEMBER_NO, room.getRoomNo())).isFalse();
+        assertThat(chatRoomMemberRepository.existsByChatRoomAndUserNo(chatRoom, MEMBER_NO)).isFalse();
+        assertThat(persistedRoom.getCurrentMateCount()).isEqualTo(1);
+        assertThat(persistedRoom.getRemaining()).isEqualTo(1);
+
+        verify(messagingTemplate).convertAndSendToUser(eq(MEMBER_NO), eq("/queue/notification"), any());
+    }
+}

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/KickRoommatePersistenceIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/KickRoommatePersistenceIntegrationTest.java
@@ -21,7 +21,7 @@ import com.project.dorumdorum.domain.roommate.domain.repository.RoommateReposito
 import com.project.dorumdorum.domain.user.domain.entity.Gender;
 import com.project.dorumdorum.domain.user.domain.entity.Role;
 import com.project.dorumdorum.domain.user.domain.entity.User;
-import com.project.dorumdorum.domain.user.domain.repository.UserRepository;
+import com.project.dorumdorum.domain.user.domain.service.UserService;
 import com.project.dorumdorum.testsupport.TestcontainersSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -34,14 +34,21 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
+/**
+ * userNo에 FK 제약이 없으므로 실제 User 엔티티 없이 임의 ID 사용 가능.
+ * RoommateKickedEventListener 내 userService.findById() 호출은 @MockitoSpyBean으로 우회.
+ * '_kick_roommate_' 접두사로 다른 테스트 데이터와 충돌 방지.
+ */
 @SpringBootTest
 @ActiveProfiles("test")
 @DisplayName("KickRoommate 영속성 통합 테스트")
@@ -59,42 +66,32 @@ class KickRoommatePersistenceIntegrationTest {
     @MockitoBean private FirebaseMessaging firebaseMessaging;
     @MockitoBean private SimpMessagingTemplate messagingTemplate;
 
+    @MockitoSpyBean private UserService userService;
+
     @Autowired private KickRoommateUseCase kickRoommateUseCase;
-    @Autowired private UserRepository userRepository;
     @Autowired private RoomRepository roomRepository;
     @Autowired private RoommateRepository roommateRepository;
     @Autowired private ChatRoomRepository chatRoomRepository;
     @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
     @Autowired private ChatMessageRepository chatMessageRepository;
 
-    private static final String HOST_NO = "kick-host-001";
-    private static final String MEMBER_NO = "kick-member-001";
+    private static final String HOST_NO   = "test_kick_roommate_host_001";
+    private static final String MEMBER_NO = "test_kick_roommate_member_001";
 
     private Room room;
     private ChatRoom chatRoom;
 
     @BeforeEach
     void setUp() {
-        userRepository.save(User.builder()
-                .userNo(HOST_NO)
-                .email("kick-host@gachon.ac.kr")
-                .password("pw")
-                .role(Role.USER)
-                .studentNo("202400101")
-                .name("Host")
-                .nickname("HostNick")
-                .gender(Gender.MALE)
-                .build());
-        userRepository.save(User.builder()
-                .userNo(MEMBER_NO)
-                .email("kick-member@gachon.ac.kr")
+        User fakeUser = User.builder()
+                .nickname("MemberNick")
+                .name("Member")
+                .email("kick-member@test.com")
                 .password("pw")
                 .role(Role.USER)
                 .studentNo("202400102")
-                .name("Member")
-                .nickname("MemberNick")
-                .gender(Gender.MALE)
-                .build());
+                .build();
+        doReturn(fakeUser).when(userService).findById(MEMBER_NO);
 
         room = roomRepository.save(Room.builder()
                 .roomType(RoomType.TYPE_1)
@@ -105,6 +102,7 @@ class KickRoommatePersistenceIntegrationTest {
                 .gender(Gender.MALE)
                 .build());
         room.plusCurrentMate();
+        room = roomRepository.save(room);
 
         roommateRepository.save(Roommate.builder()
                 .room(room)
@@ -148,12 +146,11 @@ class KickRoommatePersistenceIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        chatMessageRepository.deleteAll();
-        chatRoomMemberRepository.deleteAll();
-        chatRoomRepository.deleteAll();
-        roommateRepository.deleteAll();
-        roomRepository.deleteAll();
-        userRepository.deleteAll();
+        chatMessageRepository.deleteAllInBatch();
+        chatRoomMemberRepository.deleteAllInBatch();
+        chatRoomRepository.deleteAllInBatch();
+        roommateRepository.deleteAllInBatch();
+        roomRepository.deleteAllInBatch();
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/DeleteRoomUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/DeleteRoomUseCaseTest.java
@@ -18,6 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
+import static com.project.dorumdorum.global.exception.code.status.RoomErrorStatus.CANNOT_DELETE_COMPLETED_ROOM;
+import static com.project.dorumdorum.global.exception.code.status.RoomErrorStatus.NO_PERMISSION_ON_ROOM;
+import static com.project.dorumdorum.global.exception.code.status.RoomErrorStatus.ROOM_HAS_MEMBERS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -41,7 +44,9 @@ class DeleteRoomUseCaseTest {
         when(room.isHost("member1")).thenReturn(false);
 
         assertThatThrownBy(() -> useCase.execute("member1", "r1"))
-                .isInstanceOf(RestApiException.class);
+                .isInstanceOf(RestApiException.class)
+                .extracting(e -> ((RestApiException) e).getErrorCode().getCode())
+                .isEqualTo(NO_PERMISSION_ON_ROOM.getCode().getCode());
 
         verify(eventPublisher, never()).publishEvent(any());
     }
@@ -55,7 +60,9 @@ class DeleteRoomUseCaseTest {
         when(room.isCompleted()).thenReturn(true);
 
         assertThatThrownBy(() -> useCase.execute("host", "r1"))
-                .isInstanceOf(RestApiException.class);
+                .isInstanceOf(RestApiException.class)
+                .extracting(e -> ((RestApiException) e).getErrorCode().getCode())
+                .isEqualTo(CANNOT_DELETE_COMPLETED_ROOM.getCode().getCode());
 
         verify(eventPublisher, never()).publishEvent(any());
     }
@@ -70,7 +77,9 @@ class DeleteRoomUseCaseTest {
         when(room.getCurrentMateCount()).thenReturn(2);
 
         assertThatThrownBy(() -> useCase.execute("host", "r1"))
-                .isInstanceOf(RestApiException.class);
+                .isInstanceOf(RestApiException.class)
+                .extracting(e -> ((RestApiException) e).getErrorCode().getCode())
+                .isEqualTo(ROOM_HAS_MEMBERS.getCode().getCode());
 
         verify(eventPublisher, never()).publishEvent(any());
     }

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/DeleteRoomUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/DeleteRoomUseCaseTest.java
@@ -1,0 +1,116 @@
+package com.project.dorumdorum.domain.room.unit.usecase;
+
+import com.project.dorumdorum.domain.checklist.domain.service.RoomRuleService;
+import com.project.dorumdorum.domain.room.application.event.RoomDeletedEvent;
+import com.project.dorumdorum.domain.room.application.usecase.DeleteRoomUseCase;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
+import com.project.dorumdorum.domain.room.domain.repository.RoomLikeRepository;
+import com.project.dorumdorum.domain.room.domain.service.RoomRequestService;
+import com.project.dorumdorum.domain.room.domain.service.RoomService;
+import com.project.dorumdorum.domain.roommate.domain.service.RoommateService;
+import com.project.dorumdorum.global.exception.RestApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteRoomUseCase Unit Tests")
+class DeleteRoomUseCaseTest {
+
+    @Mock private RoomService roomService;
+    @Mock private RoommateService roommateService;
+    @Mock private RoomRequestService roomRequestService;
+    @Mock private RoomRuleService roomRuleService;
+    @Mock private RoomLikeRepository roomLikeRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @InjectMocks private DeleteRoomUseCase useCase;
+
+    @Test
+    @DisplayName("방장이 아닌 사용자가 삭제 요청 시 NO_PERMISSION_ON_ROOM 예외")
+    void execute_WhenNotHost_ThrowsNoPermission() {
+        Room room = mock(Room.class);
+        when(roomService.findByIdForUpdate("r1")).thenReturn(room);
+        when(room.isHost("member1")).thenReturn(false);
+
+        assertThatThrownBy(() -> useCase.execute("member1", "r1"))
+                .isInstanceOf(RestApiException.class);
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("COMPLETED 상태의 방은 삭제 불가 — CANNOT_DELETE_COMPLETED_ROOM 예외")
+    void execute_WhenCompleted_ThrowsCannotDeleteCompletedRoom() {
+        Room room = mock(Room.class);
+        when(roomService.findByIdForUpdate("r1")).thenReturn(room);
+        when(room.isHost("host")).thenReturn(true);
+        when(room.isCompleted()).thenReturn(true);
+
+        assertThatThrownBy(() -> useCase.execute("host", "r1"))
+                .isInstanceOf(RestApiException.class);
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("현재 인원이 2명 이상이면 삭제 불가 — ROOM_HAS_MEMBERS 예외")
+    void execute_WhenMembersExist_ThrowsRoomHasMembers() {
+        Room room = mock(Room.class);
+        when(roomService.findByIdForUpdate("r1")).thenReturn(room);
+        when(room.isHost("host")).thenReturn(true);
+        when(room.isCompleted()).thenReturn(false);
+        when(room.getCurrentMateCount()).thenReturn(2);
+
+        assertThatThrownBy(() -> useCase.execute("host", "r1"))
+                .isInstanceOf(RestApiException.class);
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("방장 혼자일 때 삭제 성공 — cascade 삭제 및 RoomDeletedEvent 발행")
+    void execute_WhenHostAlone_DeletesAndPublishesEvent() {
+        Room room = mock(Room.class);
+        when(roomService.findByIdForUpdate("r1")).thenReturn(room);
+        when(room.isHost("host")).thenReturn(true);
+        when(room.isCompleted()).thenReturn(false);
+        when(room.getCurrentMateCount()).thenReturn(1);
+
+        useCase.execute("host", "r1");
+
+        verify(roommateService).leaveRoom("host", "r1");
+        verify(roomRequestService).deleteAllByRoom(room);
+        verify(roomRuleService).deleteByRoomNo("r1");
+        verify(roomLikeRepository).deleteAllByRoom(room);
+        verify(room).delete();
+        verify(eventPublisher).publishEvent(new RoomDeletedEvent("r1"));
+    }
+
+    @Test
+    @DisplayName("cascade 삭제는 룸메이트 → 요청 → 규칙 → 좋아요 → 방 소프트 삭제 순서로 수행")
+    void execute_CascadeDeletesInOrder() {
+        Room room = mock(Room.class);
+        when(roomService.findByIdForUpdate("r1")).thenReturn(room);
+        when(room.isHost("host")).thenReturn(true);
+        when(room.isCompleted()).thenReturn(false);
+        when(room.getCurrentMateCount()).thenReturn(1);
+
+        useCase.execute("host", "r1");
+
+        InOrder inOrder = inOrder(roommateService, roomRequestService, roomRuleService, roomLikeRepository, room, eventPublisher);
+        inOrder.verify(roommateService).leaveRoom("host", "r1");
+        inOrder.verify(roomRequestService).deleteAllByRoom(room);
+        inOrder.verify(roomRuleService).deleteByRoomNo("r1");
+        inOrder.verify(roomLikeRepository).deleteAllByRoom(room);
+        inOrder.verify(room).delete();
+        inOrder.verify(eventPublisher).publishEvent(new RoomDeletedEvent("r1"));
+    }
+}

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/DeleteRoomUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/DeleteRoomUseCaseTest.java
@@ -86,16 +86,17 @@ class DeleteRoomUseCaseTest {
 
         useCase.execute("host", "r1");
 
+        verify(room).delete();
         verify(roommateService).leaveRoom("host", "r1");
+        verify(roomService).flush();
         verify(roomRequestService).deleteAllByRoom(room);
         verify(roomRuleService).deleteByRoomNo("r1");
         verify(roomLikeRepository).deleteAllByRoom(room);
-        verify(room).delete();
         verify(eventPublisher).publishEvent(new RoomDeletedEvent("r1"));
     }
 
     @Test
-    @DisplayName("cascade 삭제는 룸메이트 → 요청 → 규칙 → 좋아요 → 방 소프트 삭제 순서로 수행")
+    @DisplayName("cascade 삭제는 방 소프트 삭제 → 룸메이트 제거 → flush → 요청/규칙/좋아요 삭제 순서로 수행")
     void execute_CascadeDeletesInOrder() {
         Room room = mock(Room.class);
         when(roomService.findByIdForUpdate("r1")).thenReturn(room);
@@ -105,12 +106,13 @@ class DeleteRoomUseCaseTest {
 
         useCase.execute("host", "r1");
 
-        InOrder inOrder = inOrder(roommateService, roomRequestService, roomRuleService, roomLikeRepository, room, eventPublisher);
+        InOrder inOrder = inOrder(room, roommateService, roomService, roomRequestService, roomRuleService, roomLikeRepository, eventPublisher);
+        inOrder.verify(room).delete();
         inOrder.verify(roommateService).leaveRoom("host", "r1");
+        inOrder.verify(roomService).flush();
         inOrder.verify(roomRequestService).deleteAllByRoom(room);
         inOrder.verify(roomRuleService).deleteByRoomNo("r1");
         inOrder.verify(roomLikeRepository).deleteAllByRoom(room);
-        inOrder.verify(room).delete();
         inOrder.verify(eventPublisher).publishEvent(new RoomDeletedEvent("r1"));
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/KickRoommateUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/KickRoommateUseCaseTest.java
@@ -41,6 +41,7 @@ class KickRoommateUseCaseTest {
 
         verify(roommateService).leaveRoom("member1", "r1");
         verify(room).minusCurrentMate();
+        verify(roomService).flush();
         verify(eventPublisher).publishEvent(new RoommateKickedEvent("r1", "member1"));
     }
 
@@ -70,6 +71,7 @@ class KickRoommateUseCaseTest {
                 .isInstanceOf(RestApiException.class);
 
         verify(room, never()).minusCurrentMate();
+        verify(roomService, never()).flush();
         verify(eventPublisher, never()).publishEvent(any());
     }
 
@@ -84,6 +86,7 @@ class KickRoommateUseCaseTest {
                 .isInstanceOf(RestApiException.class);
 
         verify(roommateService, never()).leaveRoom(any(), any());
+        verify(roomService, never()).flush();
         verify(eventPublisher, never()).publishEvent(any());
     }
 
@@ -98,6 +101,7 @@ class KickRoommateUseCaseTest {
                 .isInstanceOf(RestApiException.class);
 
         verify(roommateService, never()).leaveRoom(any(), any());
+        verify(roomService, never()).flush();
         verify(eventPublisher, never()).publishEvent(any());
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/roommate/unit/infra/repository/RoommateRepositoryImplTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/roommate/unit/infra/repository/RoommateRepositoryImplTest.java
@@ -51,4 +51,17 @@ class RoommateRepositoryImplTest {
         verify(queryFactory).select(org.mockito.ArgumentMatchers.<Expression<?>>any());
         verify(query).fetch();
     }
+
+    @Test
+    @DisplayName("룸메이트가 없으면 빈 리스트 반환")
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void findMyRoommates_WhenNoResults_ReturnsEmptyList() {
+        when(queryFactory.select(org.mockito.ArgumentMatchers.<Expression<?>>any())).thenReturn(query);
+        when(query.fetch()).thenReturn(List.of());
+
+        RoommateRepositoryImpl repository = new RoommateRepositoryImpl(queryFactory);
+        List<MyRoommateResponse> result = repository.findMyRoommates("u1");
+
+        assertThat(result).isEmpty();
+    }
 }

--- a/src/test/java/com/project/dorumdorum/global/security/ChatRoomAuthorizationInterceptorTest.java
+++ b/src/test/java/com/project/dorumdorum/global/security/ChatRoomAuthorizationInterceptorTest.java
@@ -1,0 +1,162 @@
+package com.project.dorumdorum.global.security;
+
+import com.project.dorumdorum.global.exception.RestApiException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("ChatRoomAuthorizationInterceptor Unit Tests")
+class ChatRoomAuthorizationInterceptorTest {
+
+    private ChatRoomAuthorizationInterceptor interceptor;
+    private MessageChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new ChatRoomAuthorizationInterceptor();
+        channel = mock(MessageChannel.class);
+    }
+
+    // ── CONNECT ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("CONNECT — sessionAttributes에 userNo가 있으면 StompPrincipal 등록")
+    void preSend_ConnectWithUserNo_RegistersPrincipal() {
+        Message<byte[]> message = connectMessage(Map.of("userNo", "user-1"));
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(result, StompHeaderAccessor.class);
+        assertThat(accessor).isNotNull();
+        assertThat(accessor.getUser()).isNotNull();
+        assertThat(accessor.getUser().getName()).isEqualTo("user-1");
+    }
+
+    @Test
+    @DisplayName("CONNECT — sessionAttributes가 없으면 원본 메시지 그대로 반환")
+    void preSend_ConnectWithoutSessionAttributes_ReturnsOriginal() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+        StompHeaderAccessor resultAccessor = MessageHeaderAccessor.getAccessor(result, StompHeaderAccessor.class);
+        assertThat(resultAccessor.getUser()).isNull();
+    }
+
+    @Test
+    @DisplayName("CONNECT — sessionAttributes에 userNo가 없으면 원본 메시지 그대로 반환")
+    void preSend_ConnectWithoutUserNo_ReturnsOriginal() {
+        Message<byte[]> message = connectMessage(new HashMap<>());
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        StompHeaderAccessor resultAccessor = MessageHeaderAccessor.getAccessor(result, StompHeaderAccessor.class);
+        assertThat(resultAccessor.getUser()).isNull();
+    }
+
+    // ── SEND ─────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("SEND — 유효한 destination + sessionAttributes가 있으면 통과")
+    void preSend_ValidSendWithSessionAttributes_PassesThrough() {
+        Message<byte[]> message = sendMessage("/app/chat-room/cr-1/send", Map.of("userNo", "user-1"));
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("SEND — sessionAttributes가 없으면 NOT_CHAT_ROOM_MEMBER 예외")
+    void preSend_SendWithoutSessionAttributes_ThrowsException() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+        accessor.setDestination("/app/chat-room/cr-1/send");
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    @DisplayName("SEND — sessionAttributes에 userNo가 없으면 NOT_CHAT_ROOM_MEMBER 예외")
+    void preSend_SendWithoutUserNo_ThrowsException() {
+        Message<byte[]> message = sendMessage("/app/chat-room/cr-1/send", new HashMap<>());
+
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    @DisplayName("SEND — prefix가 맞지 않는 destination은 검증 없이 통과")
+    void preSend_SendToUnrelatedDestination_PassesThrough() {
+        Message<byte[]> message = sendMessage("/topic/chat-room/cr-1", new HashMap<>());
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("SEND — suffix가 /send로 끝나지 않으면 검증 없이 통과")
+    void preSend_SendWithoutSendSuffix_PassesThrough() {
+        Message<byte[]> message = sendMessage("/app/chat-room/cr-1/join", new HashMap<>());
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+    }
+
+    // ── OTHER COMMANDS ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("SUBSCRIBE 명령은 검증 없이 통과")
+    void preSend_SubscribeCommand_PassesThrough() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("DISCONNECT 명령은 검증 없이 통과")
+    void preSend_DisconnectCommand_PassesThrough() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private Message<byte[]> connectMessage(Map<String, Object> sessionAttributes) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.setSessionAttributes(sessionAttributes);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private Message<byte[]> sendMessage(String destination, Map<String, Object> sessionAttributes) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+        accessor.setDestination(destination);
+        accessor.setSessionAttributes(sessionAttributes);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+}

--- a/src/test/java/com/project/dorumdorum/global/security/JwtPrincipalHandshakeHandlerTest.java
+++ b/src/test/java/com/project/dorumdorum/global/security/JwtPrincipalHandshakeHandlerTest.java
@@ -29,6 +29,16 @@ class JwtPrincipalHandshakeHandlerTest {
         assertThat(principal.getName()).isEqualTo("user-1");
     }
 
+    @Test
+    @DisplayName("handshake attributes에 userNo가 없으면 super.determineUser로 폴백하여 null을 반환한다")
+    void determineUser_WithoutUserNo_FallsBackToSuperReturningNull() {
+        Map<String, Object> attributes = new HashMap<>();
+
+        Principal principal = handshakeHandler.determine(mock(ServerHttpRequest.class), mock(WebSocketHandler.class), attributes);
+
+        assertThat(principal).isNull();
+    }
+
     private static final class ExposedJwtPrincipalHandshakeHandler extends JwtPrincipalHandshakeHandler {
         Principal determine(ServerHttpRequest request, WebSocketHandler handler, Map<String, Object> attributes) {
             return super.determineUser(request, handler, attributes);

--- a/src/test/java/com/project/dorumdorum/global/security/JwtPrincipalHandshakeHandlerTest.java
+++ b/src/test/java/com/project/dorumdorum/global/security/JwtPrincipalHandshakeHandlerTest.java
@@ -1,0 +1,37 @@
+package com.project.dorumdorum.global.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("JwtPrincipalHandshakeHandler Unit Tests")
+class JwtPrincipalHandshakeHandlerTest {
+
+    private final ExposedJwtPrincipalHandshakeHandler handshakeHandler = new ExposedJwtPrincipalHandshakeHandler();
+
+    @Test
+    @DisplayName("handshake attributes에 userNo가 있으면 StompPrincipal을 반환한다")
+    void determineUser_WithUserNo_ReturnsStompPrincipal() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("userNo", "user-1");
+
+        Principal principal = handshakeHandler.determine(mock(ServerHttpRequest.class), mock(WebSocketHandler.class), attributes);
+
+        assertThat(principal).isNotNull();
+        assertThat(principal.getName()).isEqualTo("user-1");
+    }
+
+    private static final class ExposedJwtPrincipalHandshakeHandler extends JwtPrincipalHandshakeHandler {
+        Principal determine(ServerHttpRequest request, WebSocketHandler handler, Map<String, Object> attributes) {
+            return super.determineUser(request, handler, attributes);
+        }
+    }
+}


### PR DESCRIPTION
# 📝 Pull Request Template

## 📌 제목
fix/#91 방 관리 기능 개선 및 버그 수정 (방 삭제, 강퇴, 개인 알림, 트랜잭션 정합성)

---

## 📢 요약

이슈 #91에서 요청된 방 관리 관련 버그 수정 및 신규 기능을 구현했습니다.

### 버그 수정
- **[Bug 3]** `findMyRoommates` 쿼리에 `deletedAt IS NULL` 필터 누락으로 삭제된 룸메이트/방이 조회되는 문제 수정

### 신규 기능
- **[Feature 5]** 방 삭제 API 추가 (`DELETE /api/rooms/{roomNo}`)
  - 방장만 삭제 가능, 확정된 방/룸메이트가 있는 방은 삭제 불가
  - 방 삭제 시 RoomRequest, RoomRule, RoomLike cascade 삭제
  - 이벤트 기반으로 연관 채팅방(GROUP/DIRECT) cascade 삭제
- **[Feature 추가]** 강퇴/방 삭제 시 `/queue/notification` 개인 알림 전송
  - 채팅방 밖에 있는 사용자에게도 강퇴·방 삭제 알림 수신 가능

### 트랜잭션 정합성 수정
- `DeleteRoomUseCase`, `KickRoommateUseCase`에 `roomService.flush()` 추가
- `ChatMessageRepository` `@Modifying`에 `flushAutomatically = true` 추가
- `RoomDeletedEventListener` 채팅방 삭제를 벌크 JPQL로 교체 (`deleteByChatRoomNo`)
- `RoommateKickedEventListener` 이중 조회(`isMember + find`) → 단일 `findOptional`로 교체

🔗 **연관 이슈**: Resolves #91

---

## 🚀 PR 유형

- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [x] 🔨 코드 리팩토링
- [x] 🧪 테스트 추가 또는 리팩토링

---

## 📜 상세 설명

### 1. 방 삭제 기능 (`DeleteRoomUseCase`)

방 삭제 시 아래 순서로 처리합니다.

room.delete()           → Room 소프트 삭제 (deletedAt 설정)
roomService.flush()     → DB 반영 (이후 findByRoomNoForUpdate의 deletedAt IS NULL 조건으로 재진입 차단)
leaveRoom()             → 방장 Roommate 하드 삭제
deleteAllByRoom()       → RoomRequest, RoomRule, RoomLike 벌크 삭제
publishEvent()          → RoomDeletedEvent 발행 → 채팅방 cascade 삭제 (BEFORE_COMMIT 리스너)



> `room.delete()`를 `leaveRoom()` 앞에 배치한 이유: Roommate는 `uk_roommate_user_no` 유니크 제약으로 하드 삭제를 사용합니다. flush 전에 삭제하면 같은 트랜잭션 내 이벤트 리스너가 이미 삭제된 방을 조회할 수 있어 순서를 명시적으로 고정했습니다.

**비즈니스 규칙**
| 조건 | 에러 코드 |
|------|-----------|
| 방장이 아님 | `ROOM005` NO_PERMISSION_ON_ROOM |
| 확정된 방 | `ROOM018` CANNOT_DELETE_COMPLETED_ROOM |
| 룸메이트 존재 (2명 이상) | `ROOM017` ROOM_HAS_MEMBERS |

---

### 2. WebSocket 개인 알림 (`/queue/notification`)

기존 `/topic/` 브로드캐스트는 채팅방을 열고 있는 사용자에게만 전달됩니다. 채팅방 밖에 있는 사용자도 강퇴·방 삭제 알림을 받을 수 있도록 `/queue/notification` 개인 알림을 추가했습니다.

| 채널 | 대상 | 용도 |
|------|------|------|
| `/topic/chat-room/{chatRoomNo}` | 채팅방 구독 중인 사용자 전체 | 실시간 채팅 화면 처리 |
| `/queue/notification` | 강퇴된 사용자 / DIRECT 채팅방 지원자 | 화면 이탈 시에도 알림 수신 |

`convertAndSendToUser()` 라우팅을 위해 WebSocket Handshake 시점에 `StompPrincipal`을 등록하는 `JwtPrincipalHandshakeHandler`를 추가했습니다.

NotificationMessage { type, roomNo, chatRoomNo }

type: "ROOM_DELETED" | "KICKED_FROM_ROOM"


---

### 3. 트랜잭션 정합성 수정

**`flush()` 추가 위치**
- `DeleteRoomUseCase`: `room.delete()` 직후 → bulk DELETE 전 소프트 삭제 상태 DB 반영
- `KickRoommateUseCase`: `room.minusCurrentMate()` 직후 → BEFORE_COMMIT 리스너가 최신 인원 수 조회 가능
- `ChatMessageRepository`: `@Modifying(flushAutomatically = true)` → unreadCount 집계 오류 방지

**`RoommateKickedEventListener` 이중 조회 제거**

```java
// 이전: isMember() 체크 후 findByChatRoomAndUserNo() — 두 호출 사이 멤버 삭제 시 예외 → TX 롤백
if (chatRoomMemberService.isMember(chatRoom, userNo)) {
    ChatRoomMember member = chatRoomMemberService.findByChatRoomAndUserNo(chatRoom, userNo);
    ...
}

// 이후: 단일 Optional 조회 — 멤버 없으면 조용히 무시
chatRoomMemberService.findOptionalByChatRoomAndUserNo(chatRoom, userNo)
    .ifPresent(member -> processKick(chatRoom, member, event));
```
`RoomDeletedEventListener` 벌크 DELETE 교체

`chatRoomService.delete(entity)` (단건 엔티티 삭제)를 `chatRoomService.deleteByChatRoomNo()` (JPQL 벌크 DELETE)로 교체했습니다. BEFORE_COMMIT 컨텍스트에서 1차 캐시와 bulk DELETE가 혼재하면 캐시 불일치가 발생할 수 있어 일관성을 위해 통일했습니다.

## ✅ PR 체크리스트
- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다.
- [x]  🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ]  🔹 관련 문서를 업데이트했습니다. (필요한 경우)

## 📜 기타
- DIRECT 채팅방의 지원자가 채팅방을 열고 있을 때 방이 삭제되면 /topic/과 /queue/ 양쪽으로 알림이 전달됩니다. 두 채널의 역할이 다르므로 의도된 동작이며, FE에서 중복 처리 방지 guard가 필요합니다.
- BEFORE_COMMIT 리스너 내 WebSocket 전송 실패는 try-catch로 처리하여 TX에 영향을 주지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 방 삭제 API(호스트 검증 포함) 추가 — 연관 데이터 일괄 삭제 및 삭제 이벤트 발행
  * 채팅 알림 이벤트·전송 체계 도입 — 방별 브로드캐스트와 사용자별 알림 분리 및 재시도 로직
  * WebSocket 핸드셰이크/프린시플 개선 및 알림 페이로드(종류 포함) 정의

* **버그 수정**
  * 삭제된 방 필터링 및 채팅 권한 검증 강화
  * 채팅 관련 DB 인덱스 추가로 조회 성능 개선

* **테스트**
  * 방 삭제·강제 퇴장·웹소켓 알림 관련 단위/통합 테스트 대량 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->