### PR TITLE
[FEAT] 비동기 작업 유실 완화를 위한 Graceful Shutdown 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod} -jar /app/app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod} -jar /app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     container_name: ${CONTAINER_NAME:-dorumdorum-be}
     ports:
       - "8080:8080"
+    stop_grace_period: 45s
     env_file:
       - .env
     environment:

--- a/src/main/java/com/project/dorumdorum/global/alert/ApplicationLifecycleAlertListener.java
+++ b/src/main/java/com/project/dorumdorum/global/alert/ApplicationLifecycleAlertListener.java
@@ -1,11 +1,16 @@
 package com.project.dorumdorum.global.alert;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.boot.availability.ReadinessState;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ApplicationLifecycleAlertListener {
@@ -14,6 +19,7 @@ public class ApplicationLifecycleAlertListener {
 
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady() {
+        log.info("[Lifecycle] Application ready. readinessPath=/actuator/health/readiness livenessPath=/actuator/health/liveness");
         systemAlertPublisher.publish(
                 AlertSeverity.INFO,
                 AlertType.DEPLOYMENT,
@@ -24,11 +30,22 @@ public class ApplicationLifecycleAlertListener {
 
     @EventListener(ContextClosedEvent.class)
     public void onContextClosed() {
+        log.warn("[Lifecycle] Shutdown requested. graceful shutdown in progress");
         systemAlertPublisher.publish(
                 AlertSeverity.WARN,
                 AlertType.DEPLOYMENT,
                 "[배포] 서버 종료",
                 "dorumdorum 서버가 종료되고 있습니다."
         );
+    }
+
+    @EventListener
+    public void onReadinessChanged(AvailabilityChangeEvent<ReadinessState> event) {
+        log.info("[Availability] Readiness -> {}", event.getState());
+    }
+
+    @EventListener
+    public void onLivenessChanged(AvailabilityChangeEvent<LivenessState> event) {
+        log.info("[Availability] Liveness -> {}", event.getState());
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,9 @@
+server:
+  shutdown: graceful
+
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   datasource:
     hikari:
       maximum-pool-size: 16
@@ -44,6 +49,17 @@ springdoc:
     enabled: false
   swagger-ui:
     enabled: false
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
 
 firebase:
   service-account:


### PR DESCRIPTION
## 📌 제목
> **[FEAT] 비동기 작업 유실 완화를 위한 Graceful Shutdown 적용**

---

## 📢 요약
> 운영 환경 재시작 시 처리 중이던 요청과 비동기 작업이 즉시 중단되며 유실될 수 있는 문제를 완화하기 위해 Graceful Shutdown을 적용했습니다.
>
> `prod` 프로필에서만 애플리케이션 종료 대기 시간을 설정하고, 컨테이너가 해당 시간을 실제로 보장할 수 있도록 실행 및 종료 구성을 함께 정리했습니다. 또한 readiness/liveness
probe를 활성화해 종료 시점에 새 트래픽을 받지 않도록 운영 환경과 연동할 수 있게 했습니다.

🔗 **연관 이슈**: Resolves #89 

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [x] ✨ 새로운 기능 추가
- [x] 🏗️ 빌드 및 패키지 매니저 수정

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다. ([Commit message convention 참고](#))
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 기타
> **리뷰어가 알면 좋을 추가 사항을 적어주세요.**

- `application-prod.yml`에 `server.shutdown=graceful`, `spring.lifecycle.timeout-per-shutdown-phase=30s`를 적용했습니다.
- `application-prod.yml`에 readiness/liveness probe를 활성화해 `/actuator/health/readiness`, `/actuator/health/liveness`를 운영 헬스체크 경로로 사용할 수 있게 했습니다.
- `Dockerfile`은 `exec java ...` 형태로 수정해 `SIGTERM`이 JVM에 직접 전달되도록 변경했습니다.
- `docker-compose.yml`의 `backend` 서비스에 `stop_grace_period: 45s`를 추가해 앱의 30초 종료 대기 시간을 컨테이너 레벨에서 보장하도록 했습니다.
- 애플리케이션 시작/종료 및 readiness/liveness 상태 전환 로그를 추가해 배포 시 종료 흐름을 추적할 수 있도록 했습니다.
- 로컬 검증은 임시 DB를 사용한 `prod` 프로필 기동으로 수행했습니다.
- `SIGTERM` 전송 시 readiness가 `REFUSING_TRAFFIC`으로 전환되고, 진행 중이던 15초 요청이 `200 OK`로 완료된 뒤 프로세스가 종료되는 것을 확인했습니다.
- 테스트를 위해 일시적으로 사용한 전용 엔드포인트/환경은 모두 제거했고, 현재 변경분에는 배포용 설정만 남아 있습니다.
- Graceful Shutdown 효과를 실제 운영에서 온전히 얻으려면 LB/Ingress가 `/actuator/health/readiness`를 기준으로 트래픽 드레이닝을 수행해야 합니다.