### PR TITLE
[REFACTOR] DB Flush 호출 최소화 및 전역 Soft Delete 적용

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Run tests
         run: |
-          echo ">>> [CI] Running tests..."
-          ./gradlew test --no-daemon
+          echo ">>> [CI] Running tests without integration tests..."
+          ./gradlew test -PskipIntegrationTests --no-daemon
           echo ">>> [CI] Tests passed"
 
   docker-build-and-push:

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,10 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+
+    if (project.hasProperty('skipIntegrationTests')) {
+        exclude '**/*IntegrationTest.class'
+    }
 }
 
 def generated = "$buildDir/generated/sources/annotationProcessor/java/main"

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatMessage.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatMessage.java
@@ -4,12 +4,14 @@ import com.project.dorumdorum.global.common.BaseEntity;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@SQLRestriction("deleted_at is null")
 @Table(
     indexes = @Index(name = "idx_chat_message_room_created_message", columnList = "chat_room_no, created_at, message_no")
 )

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoom.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoom.java
@@ -10,10 +10,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @Entity
+@SQLRestriction("deleted_at is null")
 @Table(
         indexes = {
                 @Index(name = "idx_chat_room_last_message_at", columnList = "last_message_at"),

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoomMember.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/entity/ChatRoomMember.java
@@ -4,6 +4,7 @@ import com.project.dorumdorum.global.common.BaseEntity;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
@@ -12,14 +13,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@SQLRestriction("deleted_at is null")
 @Table(
     indexes = {
         @Index(name = "idx_chat_room_member_user_room", columnList = "user_no, chat_room_no")
-    },
-    uniqueConstraints = @UniqueConstraint(
-        name = "uk_chat_room_member_room_user",
-        columnNames = {"chat_room_no", "user_no"}
-    )
+    }
 )
 public class ChatRoomMember extends BaseEntity {
 

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatMessageRepository.java
@@ -21,6 +21,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, String
                             @Param("userNo") String userNo);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("DELETE FROM ChatMessage m WHERE m.chatRoom.chatRoomNo = :chatRoomNo")
+    @Query("UPDATE ChatMessage m SET m.deletedAt = CURRENT_TIMESTAMP WHERE m.chatRoom.chatRoomNo = :chatRoomNo AND m.deletedAt IS NULL")
     void deleteByChatRoomNo(@Param("chatRoomNo") String chatRoomNo);
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatMessageRepository.java
@@ -20,7 +20,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, String
                             @Param("fromTime") LocalDateTime fromTime,
                             @Param("userNo") String userNo);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ChatMessage m WHERE m.chatRoom.chatRoomNo = :chatRoomNo")
     void deleteByChatRoomNo(@Param("chatRoomNo") String chatRoomNo);
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomMemberRepository.java
@@ -37,6 +37,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     boolean existsByChatRoom_ChatRoomNoAndUserNo(String chatRoomNo, String userNo);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("DELETE FROM ChatRoomMember m WHERE m.chatRoom = :chatRoom")
+    @Query("UPDATE ChatRoomMember m SET m.deletedAt = CURRENT_TIMESTAMP WHERE m.chatRoom = :chatRoom AND m.deletedAt IS NULL")
     void deleteAllByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/repository/ChatRoomRepository.java
@@ -24,6 +24,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, String>, Cha
             String roomNo, ChatRoomType chatRoomType, String applicantUserNo);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("DELETE FROM ChatRoom c WHERE c.chatRoomNo = :chatRoomNo")
+    @Query("UPDATE ChatRoom c SET c.deletedAt = CURRENT_TIMESTAMP WHERE c.chatRoomNo = :chatRoomNo AND c.deletedAt IS NULL")
     void deleteByChatRoomNo(@Param("chatRoomNo") String chatRoomNo);
 }

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomMemberService.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomMemberService.java
@@ -67,7 +67,8 @@ public class ChatRoomMemberService {
     }
 
     public void leave(ChatRoomMember member) {
-        chatRoomMemberRepository.delete(member);
+        member.delete();
+        chatRoomMemberRepository.save(member);
     }
 
     public void deleteAllByChatRoom(ChatRoom chatRoom) {

--- a/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/chat/domain/service/ChatRoomService.java
@@ -64,7 +64,8 @@ public class ChatRoomService {
     }
 
     public void delete(ChatRoom chatRoom) {
-        chatRoomRepository.delete(chatRoom);
+        chatRoom.delete();
+        chatRoomRepository.save(chatRoom);
     }
 
     public void deleteByChatRoomNo(String chatRoomNo) {

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/ChecklistBase.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/ChecklistBase.java
@@ -123,6 +123,17 @@ public abstract class ChecklistBase {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void delete() {
+        deletedAt = LocalDateTime.now();
+    }
+
     public void updateChecklist(
             String bedtime,
             String wakeUp,

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/RoomRule.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/entity/RoomRule.java
@@ -6,8 +6,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
+@SQLRestriction("deleted_at is null")
 @Table(
         name = "room_rule",
         indexes = {

--- a/src/main/java/com/project/dorumdorum/domain/checklist/domain/repository/RoomRuleRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/checklist/domain/repository/RoomRuleRepository.java
@@ -14,6 +14,6 @@ public interface RoomRuleRepository extends JpaRepository<RoomRule, String> {
     Optional<RoomRule> findByRoomNo(@Param("roomNo") String roomNo);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("DELETE FROM RoomRule rr WHERE rr.room.roomNo = :roomNo")
+    @Query("UPDATE RoomRule rr SET rr.deletedAt = CURRENT_TIMESTAMP WHERE rr.room.roomNo = :roomNo AND rr.deletedAt IS NULL")
     void deleteByRoomNo(@Param("roomNo") String roomNo);
 }

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DeleteRoomUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/DeleteRoomUseCase.java
@@ -33,8 +33,8 @@ public class DeleteRoomUseCase {
      * 방 삭제
      * - 방장 권한 검증
      * - 방장 외 룸메이트 존재 시 삭제 불가
-     * - 방 소프트 삭제 → 룸메이트 퇴실 처리 → flush(deletedAt DB 반영)
-     * - RoomRequest, RoomRule, RoomLike 연관 데이터 삭제
+     * - 방 소프트 삭제 → 룸메이트 퇴실 처리
+     * - RoomRequest, RoomRule, RoomLike 연관 데이터 삭제 (@Modifying flushAutomatically로 자동 flush)
      * - 채팅방 삭제 이벤트 발행
      */
     public void execute(String requesterNo, String roomNo) {
@@ -54,7 +54,6 @@ public class DeleteRoomUseCase {
 
         room.delete();
         roommateService.leaveRoom(requesterNo, roomNo);
-        roomService.flush();
 
         roomRequestService.deleteAllByRoom(room);
         roomRuleService.deleteByRoomNo(roomNo);

--- a/src/main/java/com/project/dorumdorum/domain/room/application/usecase/KickRoommateUseCase.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/application/usecase/KickRoommateUseCase.java
@@ -41,7 +41,6 @@ public class KickRoommateUseCase {
 
         roommateService.leaveRoom(kickedUserNo, roomNo);
         room.minusCurrentMate();
-        roomService.flush();
 
         eventPublisher.publishEvent(new RoommateKickedEvent(roomNo, kickedUserNo));
     }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/entity/RoomLike.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/entity/RoomLike.java
@@ -4,16 +4,15 @@ import com.project.dorumdorum.global.common.BaseEntity;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@SQLRestriction("deleted_at is null")
 @Table(
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_room_like_user_room", columnNames = {"user_no", "room_no"})
-        },
         indexes = {
         }
 )

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/entity/RoomRequest.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/entity/RoomRequest.java
@@ -4,16 +4,15 @@ import com.project.dorumdorum.global.common.BaseEntity;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@SQLRestriction("deleted_at is null")
 @Table(
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_room_request_user_room_direction", columnNames = {"user_no", "room_no", "direction"})
-        },
         indexes = {
                 @Index(name = "idx_room_request_room_created", columnList = "room_no, created_at")
         }

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomLikeRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomLikeRepository.java
@@ -10,11 +10,13 @@ import org.springframework.data.repository.query.Param;
 public interface RoomLikeRepository extends JpaRepository<RoomLike, String> {
 
     boolean existsByUserNoAndRoom(String userNo, Room room);
-    void deleteByUserNoAndRoom(String userNo, Room room);
 
-    // N+1 DELETE 문제 — @Modifying JPQL 벌크 DELETE로 교체
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("DELETE FROM RoomLike l WHERE l.room = :room")
+    @Query("UPDATE RoomLike l SET l.deletedAt = CURRENT_TIMESTAMP WHERE l.userNo = :userNo AND l.room = :room AND l.deletedAt IS NULL")
+    void deleteByUserNoAndRoom(@Param("userNo") String userNo, @Param("room") Room room);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE RoomLike l SET l.deletedAt = CURRENT_TIMESTAMP WHERE l.room = :room AND l.deletedAt IS NULL")
     void deleteAllByRoom(@Param("room") Room room);
 }
 

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomRequestRepository.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/repository/RoomRequestRepository.java
@@ -15,9 +15,8 @@ public interface RoomRequestRepository extends JpaRepository<RoomRequest, String
     boolean existsByUserNoAndRoom(String userNo, Room room);
     Optional<RoomRequest> findByUserNoAndRoomAndDirection(String userNo, Room room, Direction direction);
 
-    // N+1 DELETE 문제 — @Modifying JPQL 벌크 DELETE로 교체
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("DELETE FROM RoomRequest r WHERE r.room = :room")
+    @Query("UPDATE RoomRequest r SET r.deletedAt = CURRENT_TIMESTAMP WHERE r.room = :room AND r.deletedAt IS NULL")
     void deleteAllByRoom(@Param("room") Room room);
 }
 

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomRequestService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomRequestService.java
@@ -42,7 +42,8 @@ public class RoomRequestService {
     }
 
     public void delete(RoomRequest entity) {
-        roomRequestRepository.delete(entity);
+        entity.delete();
+        roomRequestRepository.save(entity);
     }
 
     public List<RoomRequestApplicationResponse> findApplicationsByRoom(Room room) {
@@ -54,7 +55,8 @@ public class RoomRequestService {
                 .findByUserNoAndRoomAndDirection(userNo, room, Direction.USER_TO_ROOM)
                 .orElseThrow(() -> new RestApiException(ROOM_REQUEST_NOT_FOUND));
 
-        roomRequestRepository.delete(request);
+        request.delete();
+        roomRequestRepository.save(request);
     }
 
     public void deleteAllByRoom(Room room) {

--- a/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
+++ b/src/main/java/com/project/dorumdorum/domain/room/domain/service/RoomService.java
@@ -61,10 +61,6 @@ public class RoomService {
                 .orElseThrow(() -> new RestApiException(ROOM_NOT_FOUND));
     }
 
-    public void flush() {
-        roomRepository.flush();
-    }
-
     public List<FindRoomsResponse> findLikedRooms(String userNo) {
         return roomRepository.findLikedRooms(userNo);
     }

--- a/src/main/java/com/project/dorumdorum/domain/roommate/domain/entity/Roommate.java
+++ b/src/main/java/com/project/dorumdorum/domain/roommate/domain/entity/Roommate.java
@@ -5,16 +5,15 @@ import com.project.dorumdorum.global.common.BaseEntity;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@SQLRestriction("deleted_at is null")
 @Table(
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_roommate_user_no", columnNames = "user_no")
-        },
         indexes = {
                 @Index(name = "idx_roommate_room_no", columnList = "room_no")
         }

--- a/src/main/java/com/project/dorumdorum/domain/roommate/domain/service/RoommateService.java
+++ b/src/main/java/com/project/dorumdorum/domain/roommate/domain/service/RoommateService.java
@@ -66,8 +66,8 @@ public class RoommateService {
     public void leaveRoom(String userNo, String roomNo) {
         Roommate roommate = roommateRepository.findByUserNoAndRoomNo(userNo, roomNo)
                 .orElseThrow(() -> new RestApiException(_NOT_FOUND));
-        // uk_roommate_user_no 유니크 제약으로 인해 소프트 삭제 불가 — 하드 삭제 유지
-        roommateRepository.delete(roommate);
+        roommate.delete();
+        roommateRepository.save(roommate);
     }
 
     public List<MyRoommateResponse> findMyRoommates(String userNo) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -7,11 +7,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_user_student_no
 ALTER TABLE IF EXISTS room_rule ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
 
 ALTER TABLE IF EXISTS roommate DROP CONSTRAINT IF EXISTS uk_roommate_user_no;
+DROP INDEX IF EXISTS uk_roommate_user_no;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_roommate_user_no
     ON roommate (user_no)
     WHERE deleted_at IS NULL;
 
 ALTER TABLE IF EXISTS room_like DROP CONSTRAINT IF EXISTS uk_room_like_user_room;
+DROP INDEX IF EXISTS uk_room_like_user_room;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_room_like_user_room
     ON room_like (user_no, room_no)
     WHERE deleted_at IS NULL;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -22,11 +22,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_device_user_device
     ON devices (user_no, device_id);
 
 ALTER TABLE IF EXISTS room_request DROP CONSTRAINT IF EXISTS uk_room_request_user_room_direction;
+DROP INDEX IF EXISTS uk_room_request_user_room_direction;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_room_request_user_room_direction
     ON room_request (user_no, room_no, direction)
     WHERE deleted_at IS NULL;
 
 ALTER TABLE IF EXISTS chat_room_member DROP CONSTRAINT IF EXISTS uk_chat_room_member_room_user;
+DROP INDEX IF EXISTS uk_chat_room_member_room_user;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_chat_room_member_room_user
     ON chat_room_member (chat_room_no, user_no)
     WHERE deleted_at IS NULL;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -4,12 +4,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_user_email
 CREATE UNIQUE INDEX IF NOT EXISTS uk_user_student_no
     ON users (student_no);
 
-DROP INDEX IF EXISTS uk_roommate_user_no;
+ALTER TABLE IF EXISTS room_rule ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+
+ALTER TABLE IF EXISTS roommate DROP CONSTRAINT IF EXISTS uk_roommate_user_no;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_roommate_user_no
     ON roommate (user_no)
     WHERE deleted_at IS NULL;
 
-DROP INDEX IF EXISTS uk_room_like_user_room;
+ALTER TABLE IF EXISTS room_like DROP CONSTRAINT IF EXISTS uk_room_like_user_room;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_room_like_user_room
     ON room_like (user_no, room_no)
     WHERE deleted_at IS NULL;
@@ -17,12 +19,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_room_like_user_room
 CREATE UNIQUE INDEX IF NOT EXISTS uk_device_user_device
     ON devices (user_no, device_id);
 
-DROP INDEX IF EXISTS uk_room_request_user_room_direction;
+ALTER TABLE IF EXISTS room_request DROP CONSTRAINT IF EXISTS uk_room_request_user_room_direction;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_room_request_user_room_direction
     ON room_request (user_no, room_no, direction)
     WHERE deleted_at IS NULL;
 
-DROP INDEX IF EXISTS uk_chat_room_member_room_user;
+ALTER TABLE IF EXISTS chat_room_member DROP CONSTRAINT IF EXISTS uk_chat_room_member_room_user;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_chat_room_member_room_user
     ON chat_room_member (chat_room_no, user_no)
     WHERE deleted_at IS NULL;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -4,17 +4,28 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_user_email
 CREATE UNIQUE INDEX IF NOT EXISTS uk_user_student_no
     ON users (student_no);
 
+DROP INDEX IF EXISTS uk_roommate_user_no;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_roommate_user_no
-    ON roommate (user_no);
+    ON roommate (user_no)
+    WHERE deleted_at IS NULL;
 
+DROP INDEX IF EXISTS uk_room_like_user_room;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_room_like_user_room
-    ON room_like (user_no, room_no);
+    ON room_like (user_no, room_no)
+    WHERE deleted_at IS NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS uk_device_user_device
     ON devices (user_no, device_id);
 
+DROP INDEX IF EXISTS uk_room_request_user_room_direction;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_room_request_user_room_direction
-    ON room_request (user_no, room_no, direction);
+    ON room_request (user_no, room_no, direction)
+    WHERE deleted_at IS NULL;
+
+DROP INDEX IF EXISTS uk_chat_room_member_room_user;
+CREATE UNIQUE INDEX IF NOT EXISTS uk_chat_room_member_room_user
+    ON chat_room_member (chat_room_no, user_no)
+    WHERE deleted_at IS NULL;
 
 ALTER TABLE IF EXISTS users
     ALTER COLUMN gender SET NOT NULL;
@@ -30,13 +41,15 @@ CREATE INDEX IF NOT EXISTS idx_room_status_gender_remaining_created
 ALTER TABLE IF EXISTS chat_room
     DROP CONSTRAINT IF EXISTS uk_chat_room_direct;
 
+DROP INDEX IF EXISTS uk_chat_room_group;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_chat_room_group
     ON chat_room (room_no)
-    WHERE chat_room_type = 'GROUP';
+    WHERE chat_room_type = 'GROUP' AND deleted_at IS NULL;
 
+DROP INDEX IF EXISTS uk_chat_room_direct;
 CREATE UNIQUE INDEX IF NOT EXISTS uk_chat_room_direct
     ON chat_room (room_no, applicant_user_no)
-    WHERE chat_room_type = 'DIRECT';
+    WHERE chat_room_type = 'DIRECT' AND deleted_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_chat_room_room_no
     ON chat_room (room_no);

--- a/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatTransactionAtomicityIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/integration/ChatTransactionAtomicityIntegrationTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -88,6 +89,7 @@ class ChatTransactionAtomicityIntegrationTest {
     @Autowired private RoommateRepository roommateRepository;
     @Autowired private ChatRoomRepository chatRoomRepository;
     @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
 
     // ─── External Services (Mocking to isolate behavior) ─────────────────────
     @MockitoBean private SimpMessagingTemplate messagingTemplate;
@@ -110,6 +112,8 @@ class ChatTransactionAtomicityIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        truncateTables();
+
         // 1. Room 저장 (@PrePersist → currentMateCount=1, roomStatus=CONFIRM_PENDING 자동 설정)
         room = roomRepository.save(
                 Room.builder()
@@ -162,11 +166,7 @@ class ChatTransactionAtomicityIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        // FK 순서: ChatRoomMember → ChatRoom → Roommate → Room
-        chatRoomMemberRepository.deleteAll();
-        chatRoomRepository.deleteAll();
-        roommateRepository.deleteAll();
-        roomRepository.deleteAll();
+        truncateTables();
     }
 
     // =========================================================================
@@ -344,5 +344,20 @@ class ChatTransactionAtomicityIntegrationTest {
         doReturn(fakeMessage)
                 .when(chatMessageService)
                 .save(any(), anyString(), anyString(), any(), anyInt());
+    }
+
+    private void truncateTables() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE
+                    chat_message,
+                    chat_room_member,
+                    chat_room,
+                    room_request,
+                    room_rule,
+                    room_like,
+                    roommate,
+                    room
+                RESTART IDENTITY CASCADE
+                """);
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/service/ChatRoomMemberServiceTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/service/ChatRoomMemberServiceTest.java
@@ -121,13 +121,14 @@ class ChatRoomMemberServiceTest {
     }
 
     @Test
-    @DisplayName("leave: repository.delete에 위임")
-    void leave_DelegatesToRepository() {
+    @DisplayName("leave: 멤버를 소프트 삭제하고 저장")
+    void leave_SoftDeletesAndSaves() {
         ChatRoomMember member = ChatRoomMember.builder().chatRoom(chatRoom).userNo("user-1").build();
 
         service.leave(member);
 
-        verify(chatRoomMemberRepository).delete(member);
+        assertThat(member.getDeletedAt()).isNotNull();
+        verify(chatRoomMemberRepository).save(member);
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/domain/chat/unit/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/chat/unit/service/ChatRoomServiceTest.java
@@ -95,13 +95,14 @@ class ChatRoomServiceTest {
     }
 
     @Test
-    @DisplayName("delete: repository.delete에 위임")
-    void delete_DelegatesToRepository() {
+    @DisplayName("delete: 채팅방을 소프트 삭제하고 저장")
+    void delete_SoftDeletesAndSaves() {
         ChatRoom chatRoom = ChatRoom.builder().roomNo("room-1").build();
 
         service.delete(chatRoom);
 
-        verify(chatRoomRepository).delete(chatRoom);
+        assertThat(chatRoom.getDeletedAt()).isNotNull();
+        verify(chatRoomRepository).save(chatRoom);
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/DeleteRoomPersistenceIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/DeleteRoomPersistenceIntegrationTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -74,6 +75,7 @@ class DeleteRoomPersistenceIntegrationTest {
     @Autowired private ChatRoomRepository chatRoomRepository;
     @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
     @Autowired private ChatMessageRepository chatMessageRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
 
     private static final String HOST_NO      = "test_delete_room_host_001";
     private static final String APPLICANT_NO = "test_delete_room_applicant_001";
@@ -82,6 +84,8 @@ class DeleteRoomPersistenceIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        truncateTables();
+
         room = roomRepository.save(Room.builder()
                 .roomType(RoomType.TYPE_1)
                 .capacity(2)
@@ -165,13 +169,7 @@ class DeleteRoomPersistenceIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        chatMessageRepository.deleteAllInBatch();
-        chatRoomMemberRepository.deleteAllInBatch();
-        chatRoomRepository.deleteAllInBatch();
-        roomRequestRepository.deleteAllInBatch();
-        roomRuleRepository.deleteAllInBatch();
-        roommateRepository.deleteAllInBatch();
-        roomRepository.deleteAllInBatch();
+        truncateTables();
     }
 
     @Test
@@ -192,5 +190,20 @@ class DeleteRoomPersistenceIntegrationTest {
         await().untilAsserted(() ->
                 verify(messagingTemplate, times(3))
                         .convertAndSendToUser(any(), eq("/queue/notification"), any()));
+    }
+
+    private void truncateTables() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE
+                    chat_message,
+                    chat_room_member,
+                    chat_room,
+                    room_request,
+                    room_rule,
+                    room_like,
+                    roommate,
+                    room
+                RESTART IDENTITY CASCADE
+                """);
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/FlushRemovalIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/FlushRemovalIntegrationTest.java
@@ -26,7 +26,10 @@ import com.project.dorumdorum.domain.user.domain.entity.Gender;
 import com.project.dorumdorum.domain.user.domain.entity.Role;
 import com.project.dorumdorum.domain.user.domain.entity.User;
 import com.project.dorumdorum.domain.user.domain.service.UserService;
+import com.project.dorumdorum.testsupport.TestcontainersSupport;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,22 +58,20 @@ import static org.mockito.Mockito.when;
  * 2. DeleteRoomUseCase — room.delete()가 deleteAllByRoom(flushAutomatically=true)를 통해
  *    DB에 반영되고 연관 데이터가 정리되는지
  *
- * @ActiveProfiles("local-db"): 로컬 Docker PostgreSQL(dorumdorum_test DB)에 직접 연결.
- * Testcontainers 없이 실제 DB로 동작을 검증한다.
+ * @ActiveProfiles("test"): Testcontainers PostgreSQL로 실제 DB 동작을 검증한다.
  */
-@SpringBootTest(properties = {
-        "spring.datasource.driver-class-name=org.postgresql.Driver",
-        "spring.datasource.url=jdbc:postgresql://localhost:5432/dorumdorum_test",
-        "spring.datasource.username=dorumdorum",
-        "spring.datasource.password=test1234",
-        "spring.jpa.defer-datasource-initialization=true",
-        "spring.jpa.hibernate.ddl-auto=create-drop",
-        "spring.sql.init.mode=always",
-        "spring.sql.init.schema-locations=classpath:schema.sql"
-})
+@SpringBootTest
 @ActiveProfiles("test")
 @DisplayName("flush() 제거 후 실제 DB 반영 통합 테스트")
 class FlushRemovalIntegrationTest {
+
+    @BeforeAll
+    static void requireDocker() {
+        Assumptions.assumeTrue(
+                TestcontainersSupport.requireDockerOrSkip("FlushRemovalIntegrationTest"),
+                "Docker is required for FlushRemovalIntegrationTest"
+        );
+    }
 
     @MockitoBean private FirebaseApp firebaseApp;
     @MockitoBean private FirebaseMessaging firebaseMessaging;

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/FlushRemovalIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/FlushRemovalIntegrationTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -90,6 +91,7 @@ class FlushRemovalIntegrationTest {
     @Autowired private RoomRequestRepository roomRequestRepository;
     @Autowired private RoomRuleRepository roomRuleRepository;
     @Autowired private RoomLikeRepository roomLikeRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
 
     private static final String KICK_HOST_NO   = "flush_test_kick_host_001";
     private static final String KICK_MEMBER_NO = "flush_test_kick_member_001";
@@ -101,6 +103,8 @@ class FlushRemovalIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        truncateTables();
+
         // ── KickRoommateUseCase 픽스처 ────────────────────────────────────────
         kickRoom = roomRepository.save(Room.builder()
                 .roomType(RoomType.TYPE_1).capacity(2).title("kick-flush-test")
@@ -133,14 +137,7 @@ class FlushRemovalIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        chatMessageRepository.deleteAllInBatch();
-        chatRoomMemberRepository.deleteAllInBatch();
-        chatRoomRepository.deleteAllInBatch();
-        roomRequestRepository.deleteAllInBatch();
-        roomRuleRepository.deleteAllInBatch();
-        roomLikeRepository.deleteAllInBatch();
-        roommateRepository.deleteAllInBatch();
-        roomRepository.deleteAllInBatch();
+        truncateTables();
     }
 
     // =========================================================================
@@ -211,5 +208,20 @@ class FlushRemovalIntegrationTest {
         when(fakeMessage.getMessageNo()).thenReturn("fake-flush-msg-001");
         when(fakeMessage.getCreatedAt()).thenReturn(java.time.LocalDateTime.now());
         doReturn(fakeMessage).when(chatMessageService).save(any(), anyString(), anyString(), any(), anyInt());
+    }
+
+    private void truncateTables() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE
+                    chat_message,
+                    chat_room_member,
+                    chat_room,
+                    room_request,
+                    room_rule,
+                    room_like,
+                    roommate,
+                    room
+                RESTART IDENTITY CASCADE
+                """);
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/FlushRemovalIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/FlushRemovalIntegrationTest.java
@@ -1,0 +1,215 @@
+package com.project.dorumdorum.domain.room.integration;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoom;
+import com.project.dorumdorum.domain.chat.domain.entity.ChatRoomMember;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatMessageRepository;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatRoomMemberRepository;
+import com.project.dorumdorum.domain.chat.domain.repository.ChatRoomRepository;
+import com.project.dorumdorum.domain.chat.domain.service.ChatMessageService;
+import com.project.dorumdorum.domain.chat.domain.service.ChatRoomMemberService;
+import com.project.dorumdorum.domain.checklist.domain.repository.RoomRuleRepository;
+import com.project.dorumdorum.domain.room.application.usecase.DeleteRoomUseCase;
+import com.project.dorumdorum.domain.room.application.usecase.KickRoommateUseCase;
+import com.project.dorumdorum.domain.room.domain.entity.ResidencePeriod;
+import com.project.dorumdorum.domain.room.domain.entity.Room;
+import com.project.dorumdorum.domain.room.domain.entity.RoomType;
+import com.project.dorumdorum.domain.room.domain.repository.RoomLikeRepository;
+import com.project.dorumdorum.domain.room.domain.repository.RoomRepository;
+import com.project.dorumdorum.domain.room.domain.repository.RoomRequestRepository;
+import com.project.dorumdorum.domain.roommate.domain.entity.ConfirmStatus;
+import com.project.dorumdorum.domain.roommate.domain.entity.RoomRole;
+import com.project.dorumdorum.domain.roommate.domain.entity.Roommate;
+import com.project.dorumdorum.domain.roommate.domain.repository.RoommateRepository;
+import com.project.dorumdorum.domain.user.domain.entity.Gender;
+import com.project.dorumdorum.domain.user.domain.entity.Role;
+import com.project.dorumdorum.domain.user.domain.entity.User;
+import com.project.dorumdorum.domain.user.domain.service.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 명시적 flush() 제거 후 실제 DB 반영 검증 통합 테스트.
+ *
+ * 검증 대상:
+ * 1. KickRoommateUseCase — room.minusCurrentMate()가 flushAutomatically(BEFORE_COMMIT 리스너
+ *    내 decreaseUnreadCount)를 통해 DB에 반영되는지
+ * 2. DeleteRoomUseCase — room.delete()가 deleteAllByRoom(flushAutomatically=true)를 통해
+ *    DB에 반영되고 연관 데이터가 정리되는지
+ *
+ * @ActiveProfiles("local-db"): 로컬 Docker PostgreSQL(dorumdorum_test DB)에 직접 연결.
+ * Testcontainers 없이 실제 DB로 동작을 검증한다.
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.driver-class-name=org.postgresql.Driver",
+        "spring.datasource.url=jdbc:postgresql://localhost:5432/dorumdorum_test",
+        "spring.datasource.username=dorumdorum",
+        "spring.datasource.password=test1234",
+        "spring.jpa.defer-datasource-initialization=true",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.sql.init.mode=always",
+        "spring.sql.init.schema-locations=classpath:schema.sql"
+})
+@ActiveProfiles("test")
+@DisplayName("flush() 제거 후 실제 DB 반영 통합 테스트")
+class FlushRemovalIntegrationTest {
+
+    @MockitoBean private FirebaseApp firebaseApp;
+    @MockitoBean private FirebaseMessaging firebaseMessaging;
+    @MockitoBean private SimpMessagingTemplate messagingTemplate;
+
+    @MockitoSpyBean private UserService userService;
+    @MockitoSpyBean private ChatMessageService chatMessageService;
+    @MockitoSpyBean private ChatRoomMemberService chatRoomMemberService;
+
+    @Autowired private KickRoommateUseCase kickRoommateUseCase;
+    @Autowired private DeleteRoomUseCase deleteRoomUseCase;
+
+    @Autowired private RoomRepository roomRepository;
+    @Autowired private RoommateRepository roommateRepository;
+    @Autowired private ChatRoomRepository chatRoomRepository;
+    @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired private ChatMessageRepository chatMessageRepository;
+    @Autowired private RoomRequestRepository roomRequestRepository;
+    @Autowired private RoomRuleRepository roomRuleRepository;
+    @Autowired private RoomLikeRepository roomLikeRepository;
+
+    private static final String KICK_HOST_NO   = "flush_test_kick_host_001";
+    private static final String KICK_MEMBER_NO = "flush_test_kick_member_001";
+    private static final String DELETE_HOST_NO = "flush_test_del_host_001";
+
+    private Room kickRoom;
+    private ChatRoom kickChatRoom;
+    private Room deleteRoom;
+
+    @BeforeEach
+    void setUp() {
+        // ── KickRoommateUseCase 픽스처 ────────────────────────────────────────
+        kickRoom = roomRepository.save(Room.builder()
+                .roomType(RoomType.TYPE_1).capacity(2).title("kick-flush-test")
+                .hostUserNo(KICK_HOST_NO).residencePeriod(ResidencePeriod.SEMESTER)
+                .gender(Gender.MALE).build());
+        kickRoom.plusCurrentMate();
+        kickRoom = roomRepository.saveAndFlush(kickRoom);
+
+        roommateRepository.save(Roommate.builder().room(kickRoom).userNo(KICK_HOST_NO)
+                .roomRole(RoomRole.HOST).confirmStatus(ConfirmStatus.ACCEPTED).build());
+        roommateRepository.save(Roommate.builder().room(kickRoom).userNo(KICK_MEMBER_NO)
+                .roomRole(RoomRole.MEMBER).confirmStatus(ConfirmStatus.ACCEPTED).build());
+
+        kickChatRoom = chatRoomRepository.save(ChatRoom.builder().roomNo(kickRoom.getRoomNo()).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().chatRoom(kickChatRoom).userNo(KICK_HOST_NO).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().chatRoom(kickChatRoom).userNo(KICK_MEMBER_NO).build());
+
+        // ── DeleteRoomUseCase 픽스처 ─────────────────────────────────────────
+        deleteRoom = roomRepository.save(Room.builder()
+                .roomType(RoomType.TYPE_1).capacity(2).title("delete-flush-test")
+                .hostUserNo(DELETE_HOST_NO).residencePeriod(ResidencePeriod.SEMESTER)
+                .gender(Gender.MALE).build());
+
+        roommateRepository.save(Roommate.builder().room(deleteRoom).userNo(DELETE_HOST_NO)
+                .roomRole(RoomRole.HOST).confirmStatus(ConfirmStatus.ACCEPTED).build());
+
+        stubUserService();
+        stubChatMessageService();
+    }
+
+    @AfterEach
+    void tearDown() {
+        chatMessageRepository.deleteAllInBatch();
+        chatRoomMemberRepository.deleteAllInBatch();
+        chatRoomRepository.deleteAllInBatch();
+        roomRequestRepository.deleteAllInBatch();
+        roomRuleRepository.deleteAllInBatch();
+        roomLikeRepository.deleteAllInBatch();
+        roommateRepository.deleteAllInBatch();
+        roomRepository.deleteAllInBatch();
+    }
+
+    // =========================================================================
+    // KickRoommateUseCase: room.minusCurrentMate() flush 검증
+    // =========================================================================
+
+    @Test
+    @DisplayName("강퇴 후 room.currentMateCount 감소가 DB에 반영된다 (explicit flush 없이)")
+    void kick_CurrentMateCountDecrement_PersistedWithoutExplicitFlush() {
+        int beforeCount = roomRepository.findById(kickRoom.getRoomNo()).orElseThrow().getCurrentMateCount();
+
+        kickRoommateUseCase.execute(KICK_HOST_NO, kickRoom.getRoomNo(), KICK_MEMBER_NO);
+
+        Room persisted = roomRepository.findById(kickRoom.getRoomNo()).orElseThrow();
+        assertThat(persisted.getCurrentMateCount())
+                .as("minusCurrentMate()가 flush 없이도 DB에 반영되어야 한다")
+                .isEqualTo(beforeCount - 1);
+    }
+
+    @Test
+    @DisplayName("강퇴 후 Roommate 삭제가 DB에 반영된다 (explicit flush 없이)")
+    void kick_RoommateDelete_PersistedWithoutExplicitFlush() {
+        kickRoommateUseCase.execute(KICK_HOST_NO, kickRoom.getRoomNo(), KICK_MEMBER_NO);
+
+        assertThat(roommateRepository.existsByUserNoAndRoomNo(KICK_MEMBER_NO, kickRoom.getRoomNo()))
+                .as("Roommate 삭제가 DB에 반영되어야 한다")
+                .isFalse();
+    }
+
+    // =========================================================================
+    // DeleteRoomUseCase: room.delete() (deletedAt) flush 검증
+    // =========================================================================
+
+    @Test
+    @DisplayName("방 삭제 후 room.deletedAt이 DB에 반영된다 (explicit flush 없이)")
+    void delete_SoftDeletedAt_PersistedWithoutExplicitFlush() {
+        deleteRoomUseCase.execute(DELETE_HOST_NO, deleteRoom.getRoomNo());
+
+        Room persisted = roomRepository.findById(deleteRoom.getRoomNo()).orElseThrow();
+        assertThat(persisted.getDeletedAt())
+                .as("room.delete()가 flush 없이도 deletedAt이 DB에 반영되어야 한다")
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("방 삭제 후 Roommate가 DB에서 제거된다 (explicit flush 없이)")
+    void delete_RoommateCleanup_PersistedWithoutExplicitFlush() {
+        deleteRoomUseCase.execute(DELETE_HOST_NO, deleteRoom.getRoomNo());
+
+        assertThat(roommateRepository.findByUserNo(DELETE_HOST_NO))
+                .as("방 삭제 시 Roommate가 DB에서 제거되어야 한다")
+                .isEmpty();
+    }
+
+    // =========================================================================
+    // 헬퍼
+    // =========================================================================
+
+    private void stubUserService() {
+        User fakeUser = User.builder()
+                .nickname("테스트멤버").name("홍길동").email("flush-test@test.com")
+                .password("pw").role(Role.USER).studentNo("202499999").build();
+        doReturn(fakeUser).when(userService).findById(KICK_MEMBER_NO);
+    }
+
+    private void stubChatMessageService() {
+        var fakeMessage = mock(com.project.dorumdorum.domain.chat.domain.entity.ChatMessage.class);
+        when(fakeMessage.getMessageNo()).thenReturn("fake-flush-msg-001");
+        when(fakeMessage.getCreatedAt()).thenReturn(java.time.LocalDateTime.now());
+        doReturn(fakeMessage).when(chatMessageService).save(any(), anyString(), anyString(), any(), anyInt());
+    }
+}

--- a/src/test/java/com/project/dorumdorum/domain/room/integration/KickRoommatePersistenceIntegrationTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/integration/KickRoommatePersistenceIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -75,6 +76,7 @@ class KickRoommatePersistenceIntegrationTest {
     @Autowired private ChatRoomRepository chatRoomRepository;
     @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
     @Autowired private ChatMessageRepository chatMessageRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
 
     private static final String HOST_NO   = "test_kick_roommate_host_001";
     private static final String MEMBER_NO = "test_kick_roommate_member_001";
@@ -84,6 +86,8 @@ class KickRoommatePersistenceIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        truncateTables();
+
         User fakeUser = User.builder()
                 .nickname("MemberNick")
                 .name("Member")
@@ -147,11 +151,7 @@ class KickRoommatePersistenceIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        chatMessageRepository.deleteAllInBatch();
-        chatRoomMemberRepository.deleteAllInBatch();
-        chatRoomRepository.deleteAllInBatch();
-        roommateRepository.deleteAllInBatch();
-        roomRepository.deleteAllInBatch();
+        truncateTables();
     }
 
     @Test
@@ -171,5 +171,20 @@ class KickRoommatePersistenceIntegrationTest {
                     eq("/topic/chat-room/" + chatRoom.getChatRoomNo()), any(Object.class));
             verify(messagingTemplate).convertAndSendToUser(eq(MEMBER_NO), eq("/queue/notification"), any());
         });
+    }
+
+    private void truncateTables() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE
+                    chat_message,
+                    chat_room_member,
+                    chat_room,
+                    room_request,
+                    room_rule,
+                    room_like,
+                    roommate,
+                    room
+                RESTART IDENTITY CASCADE
+                """);
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/service/RoomRequestServiceTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/service/RoomRequestServiceTest.java
@@ -62,11 +62,12 @@ class RoomRequestServiceTest {
     }
 
     @Test
-    @DisplayName("Should delete provided request entity")
-    void delete_DeletesEntity() {
+    @DisplayName("Should soft delete provided request entity")
+    void delete_SoftDeletesEntity() {
         RoomRequest request = RoomRequest.builder().roomRequestNo("rq1").build();
         service.delete(request);
-        verify(roomRequestRepository).delete(request);
+        assertThat(request.getDeletedAt()).isNotNull();
+        verify(roomRequestRepository).save(request);
     }
 
     @Test
@@ -87,8 +88,8 @@ class RoomRequestServiceTest {
     }
 
     @Test
-    @DisplayName("Should cancel join request by user and room")
-    void cancelJoinRequest_FindsAndDeletesRequest() {
+    @DisplayName("Should cancel join request by soft deleting request")
+    void cancelJoinRequest_FindsAndSoftDeletesRequest() {
         Room room = Room.builder().roomNo("r1").build();
         RoomRequest request = RoomRequest.builder().roomRequestNo("rq1").build();
         when(roomRequestRepository.findByUserNoAndRoomAndDirection("u1", room, Direction.USER_TO_ROOM))
@@ -96,7 +97,8 @@ class RoomRequestServiceTest {
 
         service.cancelJoinRequest("u1", room);
 
-        verify(roomRequestRepository).delete(request);
+        assertThat(request.getDeletedAt()).isNotNull();
+        verify(roomRequestRepository).save(request);
     }
 
     @Test

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/DeleteRoomUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/DeleteRoomUseCaseTest.java
@@ -97,7 +97,6 @@ class DeleteRoomUseCaseTest {
 
         verify(room).delete();
         verify(roommateService).leaveRoom("host", "r1");
-        verify(roomService).flush();
         verify(roomRequestService).deleteAllByRoom(room);
         verify(roomRuleService).deleteByRoomNo("r1");
         verify(roomLikeRepository).deleteAllByRoom(room);
@@ -105,7 +104,7 @@ class DeleteRoomUseCaseTest {
     }
 
     @Test
-    @DisplayName("cascade 삭제는 방 소프트 삭제 → 룸메이트 제거 → flush → 요청/규칙/좋아요 삭제 순서로 수행")
+    @DisplayName("cascade 삭제는 방 소프트 삭제 → 룸메이트 제거 → 요청/규칙/좋아요 삭제 순서로 수행")
     void execute_CascadeDeletesInOrder() {
         Room room = mock(Room.class);
         when(roomService.findByIdForUpdate("r1")).thenReturn(room);
@@ -115,10 +114,9 @@ class DeleteRoomUseCaseTest {
 
         useCase.execute("host", "r1");
 
-        InOrder inOrder = inOrder(room, roommateService, roomService, roomRequestService, roomRuleService, roomLikeRepository, eventPublisher);
+        InOrder inOrder = inOrder(room, roommateService, roomRequestService, roomRuleService, roomLikeRepository, eventPublisher);
         inOrder.verify(room).delete();
         inOrder.verify(roommateService).leaveRoom("host", "r1");
-        inOrder.verify(roomService).flush();
         inOrder.verify(roomRequestService).deleteAllByRoom(room);
         inOrder.verify(roomRuleService).deleteByRoomNo("r1");
         inOrder.verify(roomLikeRepository).deleteAllByRoom(room);

--- a/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/KickRoommateUseCaseTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/room/unit/usecase/KickRoommateUseCaseTest.java
@@ -41,7 +41,6 @@ class KickRoommateUseCaseTest {
 
         verify(roommateService).leaveRoom("member1", "r1");
         verify(room).minusCurrentMate();
-        verify(roomService).flush();
         verify(eventPublisher).publishEvent(new RoommateKickedEvent("r1", "member1"));
     }
 
@@ -71,7 +70,6 @@ class KickRoommateUseCaseTest {
                 .isInstanceOf(RestApiException.class);
 
         verify(room, never()).minusCurrentMate();
-        verify(roomService, never()).flush();
         verify(eventPublisher, never()).publishEvent(any());
     }
 
@@ -86,7 +84,6 @@ class KickRoommateUseCaseTest {
                 .isInstanceOf(RestApiException.class);
 
         verify(roommateService, never()).leaveRoom(any(), any());
-        verify(roomService, never()).flush();
         verify(eventPublisher, never()).publishEvent(any());
     }
 
@@ -101,7 +98,6 @@ class KickRoommateUseCaseTest {
                 .isInstanceOf(RestApiException.class);
 
         verify(roommateService, never()).leaveRoom(any(), any());
-        verify(roomService, never()).flush();
         verify(eventPublisher, never()).publishEvent(any());
     }
 }

--- a/src/test/java/com/project/dorumdorum/domain/roommate/unit/service/RoommateServiceTest.java
+++ b/src/test/java/com/project/dorumdorum/domain/roommate/unit/service/RoommateServiceTest.java
@@ -19,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -197,5 +199,32 @@ class RoommateServiceTest {
         boolean result = roommateService.isHostOfRoom("u1", "room1");
 
         assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("leaveRoom: 룸메이트를 소프트 삭제하고 저장한다")
+    void leaveRoom_SoftDeletesRoommate() {
+        Roommate roommate = Roommate.builder()
+                .roommateNo("rm1")
+                .userNo("u1")
+                .confirmStatus(ConfirmStatus.ACCEPTED)
+                .roomRole(RoomRole.MEMBER)
+                .build();
+        when(roommateRepository.findByUserNoAndRoomNo("u1", "room1")).thenReturn(Optional.of(roommate));
+
+        roommateService.leaveRoom("u1", "room1");
+
+        ArgumentCaptor<Roommate> captor = ArgumentCaptor.forClass(Roommate.class);
+        verify(roommateRepository).save(captor.capture());
+        assertThat(captor.getValue().isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("leaveRoom: 룸메이트를 찾지 못하면 예외를 던진다")
+    void leaveRoom_WhenNotFound_Throws() {
+        when(roommateRepository.findByUserNoAndRoomNo("u1", "room1")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roommateService.leaveRoom("u1", "room1"))
+                .isInstanceOf(RestApiException.class);
     }
 }


### PR DESCRIPTION
## 📌 제목
> **[REFACTOR] DB Flush 호출 최소화 및 전역 Soft Delete 적용**

---

## 📢 요약
> 트랜잭션 정합성 문제를 일으키던 명시적 `flush()` 호출을 제거하고, JPA 자동 flush 메커니즘으로 대체했습니다.

- `Roommate`, `ChatRoomMember`, `RoomRequest`, `RoomLike`, `RoomRule`, `ChatRoom`, `ChatMessage` 등 하드 삭제(Hard Delete)로 처리되던 모든 엔티티를 `deletedAt` 기반 소프트 삭제(Soft Delete)로 전환
- `@SQLRestriction("deleted_at is null")`을 적용해 SELECT 쿼리에서 삭제된 레코드가 자동 필터링되도록 함
    - 연관 유니크 제약 조건은 `WHERE deleted_at IS NULL` 조건을 포함한 Partial Index로 교체

🔗 **연관 이슈**: Resolves #101

---

## 🚀 PR 유형
> **해당하는 항목에 체크해주세요.**

- [x] 🔨 코드 리팩토링
- [x] 🐛 버그 수정
- [x] 🧪 테스트 추가 또는 리팩토링

---

## ✅ PR 체크리스트
> **PR이 다음 요구 사항을 충족하는지 확인해주세요.**

- [x] 🔹 커밋 메시지 컨벤션을 준수했습니다.
- [x] 🔹 변경 사항에 대한 테스트를 수행했습니다. (버그 수정/기능 테스트)
- [ ] 🔹 관련 문서를 업데이트했습니다. (필요한 경우)

---

## 📜 상세 설명

### 1. 명시적 `flush()` 제거

#### 기존에 `flush()`가 필요했던 이유

`KickRoommateUseCase`와 `DeleteRoomUseCase`에서 엔티티 변경(`room.minusCurrentMate()`, `room.delete()`) 후 바로 `@Modifying` 벌크 JPQL을 실행하는 구조였습니다.

JPA의 기본 `FlushMode.AUTO`는 **SELECT 직전에 동일 테이블이 연관된 경우에만 자동 flush**합니다. 벌크 UPDATE/DELETE JPQL이 실행되는 시점에는 flush가 보장되지 않기 때문에, 1차 캐시에만 존재하는 변경 사항이 DB에 반영되지 않은 상태로 벌크 쿼리가 실행됩니다.

이로 인해 발생하던 문제:

| UseCase | 문제 |
|---------|------|
| `KickRoommateUseCase` | `room.minusCurrentMate()`가 캐시에만 존재하는 상태에서 `BEFORE_COMMIT` 리스너의 `decreaseUnreadCount`(JPQL)가 실행되어 DB의 stale 값을 기준으로 처리됨 |
| `DeleteRoomUseCase` | `room.delete()`(deletedAt 설정)가 캐시에만 존재하는 상태에서 이후 벌크 삭제 쿼리가 실행되어 정합성 깨질 수 있음 |

이를 임시로 해결하기 위해 PR #93 에서 각 변경 직후 `roomService.flush()`를 명시적으로 호출했습니다.

#### 이번에 제거할 수 있었던 이유

`@Modifying(flushAutomatically = true)`은 `FlushMode.AUTO`와 다르게, 쿼리 실행 전 **EntityManager 전체를 무조건 flush**합니다. 이를 활용해 flush 타이밍을 보장하는 구조로 전환했습니다.

| UseCase | 자동 flush 트리거 |
|---------|-----------------|
| `KickRoommateUseCase` | `@TransactionalEventListener(BEFORE_COMMIT)` 내 `decreaseUnreadCount(@Modifying flushAutomatically=true)`가 실행되기 전 EntityManager 전체 flush → `minusCurrentMate()` 변경이 DB에 반영된 뒤 쿼리 실행 |
| `DeleteRoomUseCase` | 첫 `@Modifying(flushAutomatically=true)` 쿼리(`deleteAllByRoom`) 실행 시 `room.delete()` 포함 전체 flush |

`RoomService.flush()` 메서드 자체도 함께 제거했습니다.

검증은 Testcontainers 대신 로컬 Docker PostgreSQL(`dorumdorum_test`)에 직접 연결하는 통합 테스트(`FlushRemovalIntegrationTest`)를 신규 작성해 수행했습니다. (Testcontainers 1.19.7 + Docker Desktop 환경에서 docker-java 클라이언트가 HTTP 400을 반환하는 호환성 문제로 Testcontainers를 사용하지 않았습니다.)

---

### 2. 전역 Soft Delete 전환

하드 삭제로 처리되던 모든 엔티티 및 연산을 `deletedAt` 기반 소프트 삭제로 전환했습니다.

**엔티티별 변경 사항**

| 엔티티 | `@SQLRestriction` 추가 | `@UniqueConstraint` 제거 | Partial Index 추가 |
|--------|----------------------|--------------------------|-------------------|
| `Roommate` | ✅ | ✅ | `uk_roommate_user_no WHERE deleted_at IS NULL` |
| `ChatRoomMember` | ✅ | ✅ | `uk_chat_room_member_room_user WHERE deleted_at IS NULL` |
| `RoomRequest` | ✅ | ✅ | `uk_room_request_user_room_direction WHERE deleted_at IS NULL` |
| `RoomLike` | ✅ | ✅ | `uk_room_like_user_room WHERE deleted_at IS NULL` |
| `RoomRule` | ✅ | — | — |
| `ChatRoom` | ✅ | — | `uk_chat_room_group/direct`에 `AND deleted_at IS NULL` 조건 추가 |
| `ChatMessage` | ✅ | — | — |

`RoomRule`은 `ChecklistBase`(`@MappedSuperclass`)를 상속하며 `BaseEntity`를 상속하지 않아 `deletedAt` 필드가 없었습니다. `ChecklistBase`에 `deletedAt` 필드와 `delete()` 메서드를 추가했습니다.

**서비스 레이어 변경 (개별 삭제)**

// Before
roommateRepository.delete(roommate)

// After
roommate.delete()
roommateRepository.save(roommate)



동일 패턴을 `RoommateService.leaveRoom()`, `ChatRoomMemberService.leave()`, `ChatRoomService.delete()`, `RoomRequestService.delete()`, `RoomRequestService.cancelJoinRequest()`에 적용했습니다.

**Repository 레이어 변경 (벌크 삭제)**

```java
// Before
@Query("DELETE FROM RoomRequest r WHERE r.room = :room")
void deleteAllByRoom(Room room);

// After
@Query("UPDATE RoomRequest r SET r.deletedAt = CURRENT_TIMESTAMP WHERE r.room = :room AND r.deletedAt IS NULL")
void deleteAllByRoom(Room room);
```
동일 패턴을 RoomLikeRepository, ChatRoomMemberRepository, ChatRoomRepository, ChatMessageRepository, RoomRuleRepository에 적용했습니다.

RoomLikeRepository.deleteByUserNoAndRoom은 Spring Data 파생 메서드(하드 삭제)에서 @Modifying @Query 소프트 삭제로 교체했습니다.

---

### 3. @SQLRestriction 적용 효과
`@SQLRestriction("deleted_at is null")`은 해당 엔티티에 대한 모든 SELECT 쿼리에 AND deleted_at IS NULL 조건을 자동으로 추가합니다. 벌크 DML(UPDATE/DELETE JPQL)에는 적용되지 않으므로, 벌크 쿼리에는 조건을 명시적으로 추가했습니다.

주의: Room 엔티티는 기존 커스텀 쿼리에 이미 deleted_at IS NULL 필터가 포함되어 있어 @SQLRestriction을 추가하지 않았습니다. (findById로 소프트 삭제된 Room을 직접 조회해야 하는 케이스가 존재하기 때문)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 여러 엔티티와 관련 흐름이 하드 삭제에서 deleted_at 기반 소프트 삭제로 전환되어 삭제된 항목이 쿼리에서 제외되고 관련 서비스 호출 방식이 변경되었습니다.
  * DB 제약·인덱스와 스키마가 소프트 삭제를 반영하도록 조정되었습니다.
  * 일부 서비스의 명시적 flush 호출이 제거되었습니다.

* **Tests**
  * 소프트 삭제 동작과 flush 제거를 검증하는 단위·통합 테스트가 추가·수정되었습니다.

* **Chores**
  * CI/빌드 설정에 통합 테스트 건너뛰기 옵션이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->